### PR TITLE
Automate festival data ingestion, diffing, and safe publication

### DIFF
--- a/.github/workflows/ingestion.yml
+++ b/.github/workflows/ingestion.yml
@@ -1,0 +1,40 @@
+name: Festival ingestion
+
+on:
+  schedule:
+    - cron: "23 3 * * *"
+  workflow_dispatch:
+    inputs:
+      festival:
+        description: Optional festival slug
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - name: Refresh due festival sources
+        env:
+          FESTIVAL: ${{ inputs.festival }}
+        run: |
+          args=(--due --output=outputs/ingestion)
+          if [[ -n "$FESTIVAL" ]]; then args+=("--slug=$FESTIVAL"); fi
+          npm run ingest -- "${args[@]}"
+      - name: Retain review and diagnostic artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: festival-ingestion-${{ github.run_id }}
+          path: outputs/ingestion/
+          if-no-files-found: error
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ The deployable static site is written to `out/`. Festival seed data lives in
 `data/festivals.ts`. Official source availability and the setlist.fm API are
 checked automatically every three days by GitHub Actions.
 
+Festival ingestion runs daily and selects sources according to their adaptive
+daily, three-day, weekly, or archived cadence. Run one source with
+`npm run ingest -- --slug=wacken-open-air`; add `--due` to select only sources
+whose last successful check is older than its configured interval. Scheduled
+runs retain normalized candidates and review diagnostics for 30 days.
+
 ## Main scripts
 
 - `scripts/spotify_gmm_2026/festival_playlists.py` - current playlist builder for Graspop, Wacken, Rock im Park, Summer Breeze, and Impericon.

--- a/data/festival-sources.ts
+++ b/data/festival-sources.ts
@@ -1,0 +1,64 @@
+import { festivals } from "./festivals.ts";
+import type { FestivalSource, ParserStrategy, RefreshPolicy } from "../lib/ingestion/types.ts";
+
+const bySlug = new Map(festivals.map((festival) => [festival.slug, festival]));
+function source(festivalSlug: string, refreshPolicy: RefreshPolicy, strategies: ParserStrategy[] = ["json_ld_event", "html_fallback"]): FestivalSource {
+  const festival = bySlug.get(festivalSlug);
+  if (!festival) throw new Error(`Unknown festival source: ${festivalSlug}`);
+  return { festivalSlug, url: festival.officialUrl, strategies, refreshPolicy, enabled: true };
+}
+
+// Explicit inventory: adding a festival to the catalogue requires adding its source here.
+export const festivalSources: FestivalSource[] = [
+  source("rock-am-ring", "daily"),
+  source("rock-im-park", "daily"),
+  source("wacken-open-air", "daily"),
+  source("summer-breeze", "daily"),
+  source("rockharz", "every_3_days"),
+  source("hurricane", "every_3_days"),
+  source("southside", "every_3_days"),
+  source("full-force", "weekly"),
+  source("hellfest", "every_3_days"),
+  source("rock-en-seine", "weekly"),
+  source("motocultor", "weekly"),
+  source("eurockeennes", "weekly"),
+  source("download", "weekly"),
+  source("bloodstock", "daily"),
+  source("reading", "weekly"),
+  source("leeds", "weekly"),
+  source("2000trees", "weekly"),
+  source("graspop", "weekly"),
+  source("rock-werchter", "weekly"),
+  source("alcatraz", "weekly"),
+  source("nova-rock", "daily"),
+  source("frequency", "weekly"),
+  source("rock-for-people", "daily"),
+  source("brutal-assault", "weekly"),
+  source("masters-of-rock", "every_3_days"),
+  source("polandrock", "weekly"),
+  source("mystic", "every_3_days"),
+  source("rock-imperium", "daily"),
+  source("leyendas-del-rock", "daily"),
+  source("resurrection-fest", "weekly"),
+  source("mad-cool", "weekly"),
+  source("barcelona-rock-fest", "weekly"),
+  source("firenze-rocks", "weekly"),
+  source("idays", "daily"),
+  source("rock-in-roma", "weekly"),
+  source("alpen-flair", "every_3_days"),
+  source("pistoia-blues", "weekly"),
+  source("pinkpop", "every_3_days"),
+  source("roadburn", "every_3_days"),
+  source("dynamo-metal-fest", "weekly"),
+  source("greenfield", "every_3_days"),
+  source("paleo", "weekly"),
+  source("sweden-rock", "every_3_days"),
+  source("tuska", "daily"),
+  source("tons-of-rock", "weekly"),
+  source("inferno", "weekly"),
+  source("copenhell", "weekly"),
+  source("roskilde", "weekly"),
+  source("rockstadt", "every_3_days"),
+  source("metaldays", "weekly"),
+];
+export function getFestivalSource(slug: string) { return festivalSources.find((item) => item.festivalSlug === slug); }

--- a/lib/ingestion/adapters/html-fallback.ts
+++ b/lib/ingestion/adapters/html-fallback.ts
@@ -1,0 +1,120 @@
+import type { FestivalCandidate, FestivalSource, FieldEvidence } from "../types.ts";
+import { INGESTION_SCHEMA_VERSION } from "../types.ts";
+
+type SupportedField = FieldEvidence["field"];
+
+function decode(value: string): string {
+  return value
+    .replace(/&amp;/gi, "&")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;|&apos;/gi, "'")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&#(\d+);/g, (_, code: string) => String.fromCodePoint(Number(code)))
+    .replace(/&#x([\da-f]+);/gi, (_, code: string) => String.fromCodePoint(Number.parseInt(code, 16)))
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function attributes(tag: string): Map<string, string> {
+  const result = new Map<string, string>();
+  for (const match of tag.matchAll(/([^\s=/>]+)\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+))/g)) {
+    result.set(match[1].toLowerCase(), decode(match[2] ?? match[3] ?? match[4] ?? ""));
+  }
+  return result;
+}
+
+function plainDate(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const match = value.match(/\b(20\d{2})[-/.](0[1-9]|1[0-2])[-/.](0[1-9]|[12]\d|3[01])\b/);
+  if (match) return `${match[1]}-${match[2]}-${match[3]}`;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.valueOf()) ? undefined : parsed.toISOString().slice(0, 10);
+}
+
+function metaContent(html: string, names: string[]): { value: string; excerpt: string } | undefined {
+  const expected = new Set(names.map((name) => name.toLowerCase()));
+  for (const match of html.matchAll(/<meta\b[^>]*>/gi)) {
+    const attrs = attributes(match[0]);
+    const key = (attrs.get("property") ?? attrs.get("name") ?? "").toLowerCase();
+    const content = attrs.get("content");
+    if (expected.has(key) && content) return { value: content, excerpt: match[0].slice(0, 500) };
+  }
+  return undefined;
+}
+
+function timeValue(html: string, role: "start" | "end"): { value: string; excerpt: string } | undefined {
+  for (const match of html.matchAll(/<time\b[^>]*>/gi)) {
+    const attrs = attributes(match[0]);
+    const marker = `${attrs.get("itemprop") ?? ""} ${attrs.get("class") ?? ""} ${attrs.get("data-role") ?? ""}`.toLowerCase();
+    if (!marker.includes(role)) continue;
+    const value = attrs.get("datetime");
+    if (value) return { value, excerpt: match[0].slice(0, 500) };
+  }
+  return undefined;
+}
+
+function ticketLink(html: string, sourceUrl: string): { value: string; excerpt: string } | undefined {
+  for (const match of html.matchAll(/<a\b[^>]*href\s*=\s*(?:"([^"]+)"|'([^']+)')[^>]*>([\s\S]*?)<\/a>/gi)) {
+    const tagAndText = decode(`${match[0].slice(0, match[0].indexOf(">") + 1)} ${match[3].replace(/<[^>]+>/g, " ")}`).toLowerCase();
+    if (!/\b(ticket|tickets|buy|shop|karten|billet|entradas)\b/.test(tagAndText)) continue;
+    try {
+      const url = new URL(decode(match[1] ?? match[2]), sourceUrl);
+      if (url.protocol === "https:") return { value: url.href, excerpt: match[0].slice(0, 500) };
+    } catch {
+      continue;
+    }
+  }
+  return undefined;
+}
+
+function markedNames(html: string): { values: string[]; excerpt: string } | undefined {
+  const values: string[] = [];
+  let excerpt = "";
+  const pattern = /<([a-z][\w:-]*)\b([^>]*(?:data-artist|itemprop\s*=\s*["']performer["']|class\s*=\s*["'][^"']*(?:artist|lineup)[^"']*["'])[^>]*)>([\s\S]*?)<\/\1>/gi;
+  for (const match of html.matchAll(pattern)) {
+    const attrs = attributes(`<${match[1]} ${match[2]}>`);
+    const value = decode(attrs.get("data-artist") ?? match[3].replace(/<[^>]+>/g, " "));
+    if (value && value.length <= 120 && !/^(line-?up|artists?|performers?)$/i.test(value)) {
+      values.push(value);
+      if (!excerpt) excerpt = match[0].slice(0, 500);
+    }
+  }
+  const byNormalizedName = new Map<string, string>();
+  for (const value of values) {
+    const normalized = value.toLocaleLowerCase();
+    if (!byNormalizedName.has(normalized)) byNormalizedName.set(normalized, value);
+  }
+  const unique = [...byNormalizedName.values()];
+  return unique.length ? { values: unique, excerpt } : undefined;
+}
+
+export function extractHtmlFallbackCandidate(html: string, source: FestivalSource, fetchedAt: string): FestivalCandidate {
+  const candidate: FestivalCandidate = {
+    schemaVersion: INGESTION_SCHEMA_VERSION,
+    festivalSlug: source.festivalSlug,
+    sourceUrl: source.url,
+    fetchedAt,
+    evidence: [],
+    warnings: [],
+  };
+  const start = metaContent(html, ["event:start_time", "event:start_date", "festival:start_date"]) ?? timeValue(html, "start");
+  const end = metaContent(html, ["event:end_time", "event:end_date", "festival:end_date"]) ?? timeValue(html, "end");
+  const city = metaContent(html, ["event:location", "festival:city", "geo.placename"]);
+  const tickets = ticketLink(html, source.url);
+  const lineup = markedNames(html);
+
+  const add = (field: SupportedField, value: string | string[] | undefined, excerpt: string | undefined) => {
+    if (value === undefined) return;
+    Object.assign(candidate, { [field]: value });
+    candidate.evidence.push({ field, sourceUrl: source.url, observedAt: fetchedAt, excerpt });
+  };
+  add("startDate", plainDate(start?.value), start?.excerpt);
+  add("endDate", plainDate(end?.value), end?.excerpt);
+  add("city", city?.value, city?.excerpt);
+  add("ticketsUrl", tickets?.value, tickets?.excerpt);
+  add("lineup", lineup?.values, lineup?.excerpt);
+
+  if (candidate.evidence.length === 0) candidate.warnings.push("HTML fallback did not find explicitly marked festival fields");
+  return candidate;
+}

--- a/lib/ingestion/adapters/json-ld.ts
+++ b/lib/ingestion/adapters/json-ld.ts
@@ -1,0 +1,114 @@
+import type { FestivalCandidate, FestivalSource, FieldEvidence } from "../types.ts";
+import { INGESTION_SCHEMA_VERSION } from "../types.ts";
+
+type JsonLd = Record<string, unknown>;
+
+function records(value: unknown): JsonLd[] {
+  if (Array.isArray(value)) return value.flatMap(records);
+  if (!value || typeof value !== "object") return [];
+  const record = value as JsonLd;
+  return [record, ...records(record["@graph"])];
+}
+
+function eventRecords(html: string): { event: JsonLd; excerpt: string }[] {
+  const events: { event: JsonLd; excerpt: string }[] = [];
+  const scriptPattern = /<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  for (const match of html.matchAll(scriptPattern)) {
+    const source = match[1].trim();
+    if (!source) continue;
+    try {
+      const parsed = JSON.parse(source);
+      for (const record of records(parsed)) {
+        const types = Array.isArray(record["@type"]) ? record["@type"] : [record["@type"]];
+        if (types.some((type) => typeof type === "string" && type.toLowerCase().endsWith("event"))) {
+          events.push({ event: record, excerpt: source.slice(0, 500) });
+        }
+      }
+    } catch {
+      continue;
+    }
+  }
+  return events;
+}
+
+function text(value: unknown): string | undefined {
+  if (typeof value === "string") return value.trim() || undefined;
+  if (value && typeof value === "object" && typeof (value as JsonLd).name === "string") return ((value as JsonLd).name as string).trim() || undefined;
+  return undefined;
+}
+
+function date(value: unknown): string | undefined {
+  const valueText = text(value);
+  if (!valueText) return undefined;
+  const plainDate = valueText.match(/^\d{4}-\d{2}-\d{2}/)?.[0];
+  if (plainDate) return plainDate;
+  const parsed = new Date(valueText);
+  return Number.isNaN(parsed.valueOf()) ? undefined : parsed.toISOString().slice(0, 10);
+}
+
+function city(location: unknown): string | undefined {
+  if (!location || typeof location !== "object") return undefined;
+  const address = (location as JsonLd).address;
+  if (typeof address === "string") return undefined;
+  if (address && typeof address === "object") return text((address as JsonLd).addressLocality);
+  return undefined;
+}
+
+function names(value: unknown): string[] | undefined {
+  if (value === undefined) return undefined;
+  const values = Array.isArray(value) ? value : [value];
+  const result = [...new Set(values.map(text).filter((name): name is string => Boolean(name)))];
+  return result.length > 0 ? result : undefined;
+}
+
+function ticketUrl(offers: unknown): string | undefined {
+  const values = Array.isArray(offers) ? offers : [offers];
+  for (const offer of values) {
+    if (typeof offer === "string" && /^https:\/\//.test(offer)) return offer;
+    if (offer && typeof offer === "object") {
+      const url = text((offer as JsonLd).url);
+      if (url && /^https:\/\//.test(url)) return url;
+    }
+  }
+  return undefined;
+}
+
+export function extractJsonLdCandidate(html: string, source: FestivalSource, fetchedAt: string): FestivalCandidate {
+  const matches = eventRecords(html);
+  const selected = matches[0];
+  const candidate: FestivalCandidate = {
+    schemaVersion: INGESTION_SCHEMA_VERSION,
+    festivalSlug: source.festivalSlug,
+    sourceUrl: source.url,
+    fetchedAt,
+    evidence: [],
+    warnings: [],
+  };
+
+  if (!selected) {
+    candidate.warnings.push("No JSON-LD Event was found");
+    return candidate;
+  }
+
+  const fields = {
+    startDate: date(selected.event.startDate),
+    endDate: date(selected.event.endDate),
+    city: city(selected.event.location),
+    lineup: names(selected.event.performer),
+    ticketsUrl: ticketUrl(selected.event.offers),
+  };
+
+  for (const [field, value] of Object.entries(fields)) {
+    if (value === undefined) continue;
+    Object.assign(candidate, { [field]: value });
+    candidate.evidence.push({ field: field as FieldEvidence["field"], sourceUrl: source.url, observedAt: fetchedAt, excerpt: selected.excerpt });
+  }
+
+  const eventStatus = text(selected.event.eventStatus)?.toLowerCase();
+  if (eventStatus?.includes("cancelled") || eventStatus?.includes("postponed")) {
+    candidate.warnings.push(`Official event status requires review: ${text(selected.event.eventStatus)}`);
+  }
+  if (matches.length > 1) candidate.warnings.push(`Multiple JSON-LD Events found (${matches.length}); the first event was selected`);
+  if (candidate.evidence.length === 0) candidate.warnings.push("JSON-LD Event did not contain supported festival fields");
+  return candidate;
+}

--- a/lib/ingestion/diff.ts
+++ b/lib/ingestion/diff.ts
@@ -1,0 +1,28 @@
+import type { Festival } from "../../data/festivals.ts";
+import type { FestivalCandidate, FestivalChange } from "./types.ts";
+
+function scalarChange(changes: FestivalChange[], field: "startDate" | "endDate" | "city" | "ticketsUrl" | "status", before: string | undefined, after: string | undefined) {
+  if (after === undefined || before === after) return;
+  const kind = field === "city" ? "city_changed" : field === "ticketsUrl" ? "tickets_changed" : field === "status" ? "status_changed" : "date_changed";
+  changes.push({ kind, field, before, after, reviewRequired: field === "startDate" || field === "endDate" });
+}
+
+function listChanges(changes: FestivalChange[], field: "lineup" | "headliners", before: string[], after: string[] | undefined) {
+  if (!after) return;
+  const oldNames = new Map(before.map((name) => [name.toLocaleLowerCase(), name]));
+  const newNames = new Map(after.map((name) => [name.toLocaleLowerCase(), name]));
+  for (const [key, name] of newNames) if (!oldNames.has(key)) changes.push({ kind: field === "headliners" ? "headliner_added" : "artist_added", field, after: name, reviewRequired: false });
+  for (const [key, name] of oldNames) if (!newNames.has(key)) changes.push({ kind: field === "headliners" ? "headliner_removed" : "artist_removed", field, before: name, reviewRequired: true, reason: "Removals require confirmation" });
+}
+
+export function diffFestival(current: Festival, candidate: FestivalCandidate): FestivalChange[] {
+  const changes: FestivalChange[] = [];
+  scalarChange(changes, "startDate", current.startDate, candidate.startDate);
+  scalarChange(changes, "endDate", current.endDate, candidate.endDate);
+  scalarChange(changes, "city", current.city, candidate.city);
+  scalarChange(changes, "ticketsUrl", current.ticketsUrl, candidate.ticketsUrl);
+  scalarChange(changes, "status", current.status, candidate.status);
+  listChanges(changes, "headliners", current.headliners, candidate.headliners);
+  listChanges(changes, "lineup", current.lineup, candidate.lineup);
+  return changes;
+}

--- a/lib/ingestion/extract.ts
+++ b/lib/ingestion/extract.ts
@@ -1,0 +1,32 @@
+import { extractHtmlFallbackCandidate } from "./adapters/html-fallback.ts";
+import { extractJsonLdCandidate } from "./adapters/json-ld.ts";
+import type { FestivalCandidate, FestivalSource, FieldEvidence } from "./types.ts";
+import { INGESTION_SCHEMA_VERSION } from "./types.ts";
+
+const supportedFields: FieldEvidence["field"][] = ["startDate", "endDate", "city", "headliners", "lineup", "ticketsUrl", "status"];
+
+export function extractFestivalCandidate(html: string, source: FestivalSource, fetchedAt: string): FestivalCandidate {
+  const candidates = source.strategies.flatMap((strategy) => {
+    if (strategy === "json_ld_event") return [extractJsonLdCandidate(html, source, fetchedAt)];
+    if (strategy === "html_fallback") return [extractHtmlFallbackCandidate(html, source, fetchedAt)];
+    return [];
+  });
+  const merged: FestivalCandidate = {
+    schemaVersion: INGESTION_SCHEMA_VERSION,
+    festivalSlug: source.festivalSlug,
+    sourceUrl: source.url,
+    fetchedAt,
+    evidence: [],
+    warnings: [],
+  };
+  for (const candidate of candidates) {
+    for (const field of supportedFields) {
+      if (merged[field] === undefined && candidate[field] !== undefined) Object.assign(merged, { [field]: candidate[field] });
+    }
+    merged.evidence.push(...candidate.evidence.filter(({ field }) => merged[field] !== undefined));
+  }
+  const hasEvidence = new Set(merged.evidence.map(({ field }) => field));
+  merged.evidence = merged.evidence.filter(({ field }, index, values) => values.findIndex((evidence) => evidence.field === field) === index);
+  if (hasEvidence.size === 0) merged.warnings = [...new Set(candidates.flatMap(({ warnings }) => warnings))];
+  return merged;
+}

--- a/lib/ingestion/policy.ts
+++ b/lib/ingestion/policy.ts
@@ -1,0 +1,13 @@
+import type { Festival } from "../../data/festivals.ts";
+import type { FestivalCandidate, IngestionResult } from "./types.ts";
+import { INGESTION_SCHEMA_VERSION } from "./types.ts";
+import { diffFestival } from "./diff.ts";
+
+export function evaluateCandidate(current: Festival, candidate: FestivalCandidate): IngestionResult {
+  const changes = diffFestival(current, candidate);
+  const reviewReasons = new Set(candidate.warnings);
+  if (candidate.festivalSlug !== current.slug) reviewReasons.add("Candidate slug does not match the current festival");
+  if (candidate.lineup && candidate.lineup.length === 0 && current.lineup.length > 0) reviewReasons.add("A non-empty lineup cannot be replaced by an empty lineup");
+  changes.filter((change) => change.reviewRequired).forEach((change) => reviewReasons.add(change.reason || `${change.kind} requires review`));
+  return { schemaVersion: INGESTION_SCHEMA_VERSION, festivalSlug: current.slug, sourceUrl: candidate.sourceUrl, fetchedAt: candidate.fetchedAt, changes, candidate, publishable: changes.length > 0 && reviewReasons.size === 0, reviewReasons: [...reviewReasons] };
+}

--- a/lib/ingestion/schedule.ts
+++ b/lib/ingestion/schedule.ts
@@ -1,0 +1,19 @@
+import type { FestivalSource, RefreshPolicy } from "./types.ts";
+
+const intervals: Record<RefreshPolicy, number> = {
+  daily: 24 * 60 * 60 * 1_000,
+  every_3_days: 3 * 24 * 60 * 60 * 1_000,
+  weekly: 7 * 24 * 60 * 60 * 1_000,
+  archived: 30 * 24 * 60 * 60 * 1_000,
+};
+
+export function isSourceDue(source: FestivalSource, now = new Date()): boolean {
+  if (!source.enabled) return false;
+  if (!source.lastSuccessfulCheck) return true;
+  const checkedAt = Date.parse(source.lastSuccessfulCheck);
+  return !Number.isFinite(checkedAt) || now.getTime() - checkedAt >= intervals[source.refreshPolicy];
+}
+
+export function dueFestivalSources(sources: FestivalSource[], now = new Date()): FestivalSource[] {
+  return sources.filter((source) => isSourceDue(source, now));
+}

--- a/lib/ingestion/types.ts
+++ b/lib/ingestion/types.ts
@@ -1,0 +1,42 @@
+import type { Festival } from "../../data/festivals.ts";
+
+export const INGESTION_SCHEMA_VERSION = 1 as const;
+export type RefreshPolicy = "daily" | "every_3_days" | "weekly";
+export type ParserStrategy = "json_ld_event" | "html_fallback" | "manual_review";
+
+export type FestivalSource = {
+  festivalSlug: string;
+  url: string;
+  strategies: ParserStrategy[];
+  refreshPolicy: RefreshPolicy;
+  enabled: boolean;
+};
+
+export type FieldEvidence = {
+  field: keyof Pick<Festival, "startDate" | "endDate" | "city" | "headliners" | "lineup" | "ticketsUrl" | "status">;
+  sourceUrl: string;
+  observedAt: string;
+  excerpt?: string;
+};
+
+export type FestivalCandidate = Partial<Pick<Festival, "startDate" | "endDate" | "city" | "headliners" | "lineup" | "ticketsUrl" | "status">> & {
+  schemaVersion: typeof INGESTION_SCHEMA_VERSION;
+  festivalSlug: string;
+  sourceUrl: string;
+  fetchedAt: string;
+  evidence: FieldEvidence[];
+  warnings: string[];
+};
+
+export type ChangeKind = "date_changed" | "city_changed" | "artist_added" | "artist_removed" | "headliner_added" | "headliner_removed" | "tickets_changed" | "status_changed";
+export type FestivalChange = { kind: ChangeKind; field: string; before?: string; after?: string; reviewRequired: boolean; reason?: string };
+export type IngestionResult = {
+  schemaVersion: typeof INGESTION_SCHEMA_VERSION;
+  festivalSlug: string;
+  sourceUrl: string;
+  fetchedAt: string;
+  changes: FestivalChange[];
+  candidate: FestivalCandidate;
+  publishable: boolean;
+  reviewReasons: string[];
+};

--- a/lib/ingestion/types.ts
+++ b/lib/ingestion/types.ts
@@ -1,7 +1,7 @@
 import type { Festival } from "../../data/festivals.ts";
 
 export const INGESTION_SCHEMA_VERSION = 1 as const;
-export type RefreshPolicy = "daily" | "every_3_days" | "weekly";
+export type RefreshPolicy = "daily" | "every_3_days" | "weekly" | "archived";
 export type ParserStrategy = "json_ld_event" | "html_fallback" | "manual_review";
 
 export type FestivalSource = {
@@ -10,6 +10,7 @@ export type FestivalSource = {
   strategies: ParserStrategy[];
   refreshPolicy: RefreshPolicy;
   enabled: boolean;
+  lastSuccessfulCheck?: string;
 };
 
 export type FieldEvidence = {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "typecheck": "tsc --noEmit",
     "fetch:logos": "node scripts/fetch-festival-logos.mjs",
     "check:sources": "node scripts/check-festival-sources.mjs",
+    "ingest": "node scripts/ingest-festivals.mjs",
     "test:data": "node --test tests/*.test.mjs",
     "test": "python3 -m unittest discover -s tests"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsc --noEmit",
     "fetch:logos": "node scripts/fetch-festival-logos.mjs",
     "check:sources": "node scripts/check-festival-sources.mjs",
-    "test:data": "node --test tests/festival-data.test.mjs",
+    "test:data": "node --test tests/*.test.mjs",
     "test": "python3 -m unittest discover -s tests"
   },
   "dependencies": {

--- a/scripts/ingest-festivals.mjs
+++ b/scripts/ingest-festivals.mjs
@@ -5,12 +5,14 @@ import { festivals } from "../data/festivals.ts";
 import { festivalSources } from "../data/festival-sources.ts";
 import { extractFestivalCandidate } from "../lib/ingestion/extract.ts";
 import { evaluateCandidate } from "../lib/ingestion/policy.ts";
+import { dueFestivalSources } from "../lib/ingestion/schedule.ts";
 
 const args = new Set(process.argv.slice(2));
 const slugArg = process.argv.find((value) => value.startsWith("--slug="))?.slice(7);
 const outputArg = process.argv.find((value) => value.startsWith("--output="))?.slice(9);
 const outputDirectory = path.resolve(outputArg || "outputs/ingestion");
-const selected = festivalSources.filter((source) => source.enabled && (!slugArg || source.festivalSlug === slugArg));
+const eligible = args.has("--due") ? dueFestivalSources(festivalSources) : festivalSources.filter((source) => source.enabled);
+const selected = eligible.filter((source) => !slugArg || source.festivalSlug === slugArg);
 if (selected.length === 0) throw new Error(slugArg ? `Unknown or disabled festival source: ${slugArg}` : "No enabled festival sources");
 
 await mkdir(outputDirectory, { recursive: true });

--- a/scripts/ingest-festivals.mjs
+++ b/scripts/ingest-festivals.mjs
@@ -1,0 +1,49 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { festivals } from "../data/festivals.ts";
+import { festivalSources } from "../data/festival-sources.ts";
+import { extractFestivalCandidate } from "../lib/ingestion/extract.ts";
+import { evaluateCandidate } from "../lib/ingestion/policy.ts";
+
+const args = new Set(process.argv.slice(2));
+const slugArg = process.argv.find((value) => value.startsWith("--slug="))?.slice(7);
+const outputArg = process.argv.find((value) => value.startsWith("--output="))?.slice(9);
+const outputDirectory = path.resolve(outputArg || "outputs/ingestion");
+const selected = festivalSources.filter((source) => source.enabled && (!slugArg || source.festivalSlug === slugArg));
+if (selected.length === 0) throw new Error(slugArg ? `Unknown or disabled festival source: ${slugArg}` : "No enabled festival sources");
+
+await mkdir(outputDirectory, { recursive: true });
+const summary = { schemaVersion: 1, generatedAt: new Date().toISOString(), dryRun: !args.has("--publish"), processed: 0, changed: 0, publishable: 0, reviewRequired: 0, fetchErrors: 0, results: [] };
+
+for (const source of selected) {
+  const current = festivals.find(({ slug }) => slug === source.festivalSlug);
+  if (!current) throw new Error(`No current festival for ${source.festivalSlug}`);
+  const fetchedAt = new Date().toISOString();
+  try {
+    const response = await fetch(source.url, {
+      redirect: "follow",
+      signal: AbortSignal.timeout(20_000),
+      headers: { "user-agent": "FestivalRadarBot/1.0 (+https://festivals.kir-it.de/)" },
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const html = await response.text();
+    const candidate = extractFestivalCandidate(html, source, fetchedAt);
+    const result = evaluateCandidate(current, candidate);
+    const status = result.reviewReasons.length ? "review" : result.publishable ? "publishable" : "unchanged";
+    const artifact = { status, source: { ...source, httpStatus: response.status, finalUrl: response.url }, result };
+    await writeFile(path.join(outputDirectory, `${source.festivalSlug}.json`), `${JSON.stringify(artifact, null, 2)}\n`);
+    summary.processed += 1;
+    if (result.changes.length) summary.changed += 1;
+    if (result.publishable) summary.publishable += 1;
+    if (result.reviewReasons.length) summary.reviewRequired += 1;
+    summary.results.push({ festivalSlug: source.festivalSlug, status, changes: result.changes.length, reviewReasons: result.reviewReasons });
+  } catch (error) {
+    summary.fetchErrors += 1;
+    summary.results.push({ festivalSlug: source.festivalSlug, status: "fetch_error", error: error instanceof Error ? error.message : String(error) });
+  }
+}
+
+await writeFile(path.join(outputDirectory, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
+console.log(JSON.stringify(summary));
+if (summary.fetchErrors) process.exitCode = 2;

--- a/tests/festival-data.test.mjs
+++ b/tests/festival-data.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import { festivals } from "../data/festivals.ts";
+import { festivalSources } from "../data/festival-sources.ts";
+import { INGESTION_SCHEMA_VERSION } from "../lib/ingestion/types.ts";
+import { evaluateCandidate } from "../lib/ingestion/policy.ts";
 
 test("the seed contains 50 unique festivals", () => {
   assert.equal(festivals.length, 50);
@@ -17,4 +20,38 @@ test("dated editions have valid chronological dates", () => {
 
 test("official links are HTTPS", () => {
   for (const festival of festivals) assert.match(festival.officialUrl, /^https:\/\//, festival.name);
+});
+
+test("every festival has exactly one enabled ingestion source", () => {
+  assert.equal(festivalSources.length, festivals.length);
+  assert.equal(new Set(festivalSources.map(({ festivalSlug }) => festivalSlug)).size, festivals.length);
+  assert.deepEqual(festivalSources.map(({ festivalSlug }) => festivalSlug).sort(), festivals.map(({ slug }) => slug).sort());
+  for (const source of festivalSources) {
+    assert.match(source.url, /^https:\/\//);
+    assert.equal(source.enabled, true);
+    assert.ok(source.strategies.length > 0);
+    assert.ok(["daily", "every_3_days", "weekly"].includes(source.refreshPolicy));
+  }
+});
+
+test("safe additions can publish while removals and empty replacements require review", () => {
+  const current = festivals.find(({ slug }) => slug === "wacken-open-air");
+  assert.ok(current);
+  const base = {
+    schemaVersion: INGESTION_SCHEMA_VERSION,
+    festivalSlug: current.slug,
+    sourceUrl: current.officialUrl,
+    fetchedAt: "2026-08-28T20:00:00.000Z",
+    evidence: [],
+    warnings: [],
+  };
+  const addition = evaluateCandidate(current, { ...base, lineup: [...current.lineup, "Test Artist"] });
+  assert.equal(addition.publishable, true);
+  assert.equal(addition.changes.at(-1)?.kind, "artist_added");
+  const removal = evaluateCandidate(current, { ...base, lineup: current.lineup.slice(1) });
+  assert.equal(removal.publishable, false);
+  assert.ok(removal.changes.some(({ kind }) => kind === "artist_removed"));
+  const empty = evaluateCandidate(current, { ...base, lineup: [] });
+  assert.equal(empty.publishable, false);
+  assert.ok(empty.reviewReasons.some((reason) => reason.includes("empty lineup")));
 });

--- a/tests/ingestion-extract.test.mjs
+++ b/tests/ingestion-extract.test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { extractFestivalCandidate } from "../lib/ingestion/extract.ts";
+
+const source = { festivalSlug: "example", url: "https://example.test/", strategies: ["json_ld_event", "html_fallback"], refreshPolicy: "daily", enabled: true };
+
+test("combined extraction keeps JSON-LD precedence and fills missing HTML fields", () => {
+  const html = `
+    <script type="application/ld+json">{"@type":"MusicEvent","startDate":"2027-06-01","performer":{"name":"JSON Band"}}</script>
+    <meta property="event:start_time" content="2027-07-01">
+    <meta name="festival:city" content="Berlin">
+    <a href="/tickets">Tickets</a>`;
+  const result = extractFestivalCandidate(html, source, "2026-08-28T21:20:00.000Z");
+  assert.equal(result.startDate, "2027-06-01");
+  assert.equal(result.city, "Berlin");
+  assert.deepEqual(result.lineup, ["JSON Band"]);
+  assert.equal(result.ticketsUrl, "https://example.test/tickets");
+  assert.deepEqual(result.warnings, []);
+  assert.equal(new Set(result.evidence.map(({ field }) => field)).size, result.evidence.length);
+});

--- a/tests/ingestion-html-fallback.test.mjs
+++ b/tests/ingestion-html-fallback.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { extractHtmlFallbackCandidate } from "../lib/ingestion/adapters/html-fallback.ts";
+
+const source = {
+  festivalSlug: "example-fest",
+  url: "https://festival.example/2027/",
+  strategies: ["html_fallback"],
+  refreshPolicy: "daily",
+  enabled: true,
+};
+
+test("HTML fallback extracts only explicitly marked festival data", () => {
+  const html = `
+    <meta property="event:start_time" content="2027-07-01T16:00:00+02:00">
+    <time class="festival-end" datetime="2027-07-03">3 July</time>
+    <meta name="festival:city" content="Berlin &amp; Brandenburg">
+    <div class="lineup-artist">Band A</div>
+    <span data-artist="Band B">ignored presentation</span>
+    <div class="lineup-artist">band a</div>
+    <a class="button tickets" href="/tickets">Buy tickets</a>`;
+  const candidate = extractHtmlFallbackCandidate(html, source, "2026-08-28T21:15:00.000Z");
+  assert.equal(candidate.startDate, "2027-07-01");
+  assert.equal(candidate.endDate, "2027-07-03");
+  assert.equal(candidate.city, "Berlin & Brandenburg");
+  assert.deepEqual(candidate.lineup, ["Band A", "Band B"]);
+  assert.equal(candidate.ticketsUrl, "https://festival.example/tickets");
+  assert.deepEqual(candidate.warnings, []);
+  assert.equal(candidate.evidence.length, 5);
+});
+
+test("HTML fallback refuses unmarked prose and unsafe ticket URLs", () => {
+  const html = `<p>July 1-3, 2027 in Berlin with Band A</p><a href="http://tickets.example">Tickets</a>`;
+  const candidate = extractHtmlFallbackCandidate(html, source, "2026-08-28T21:15:00.000Z");
+  assert.deepEqual(candidate.evidence, []);
+  assert.deepEqual(candidate.warnings, ["HTML fallback did not find explicitly marked festival fields"]);
+});

--- a/tests/ingestion-json-ld.test.mjs
+++ b/tests/ingestion-json-ld.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { extractJsonLdCandidate } from "../lib/ingestion/adapters/json-ld.ts";
+
+const source = {
+  festivalSlug: "example-fest",
+  url: "https://festival.example/",
+  strategies: ["json_ld_event"],
+  refreshPolicy: "daily",
+  enabled: true,
+};
+
+test("JSON-LD extraction normalizes dates, city, performers, and tickets", () => {
+  const html = `
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "MusicEvent",
+        "startDate": "2027-07-01T16:00:00+02:00",
+        "endDate": "2027-07-03",
+        "location": {"@type": "Place", "address": {"addressLocality": "Berlin"}},
+        "performer": [{"@type": "MusicGroup", "name": "Band A"}, {"name": "Band B"}],
+        "offers": {"@type": "Offer", "url": "https://tickets.example/fest"}
+      }
+    </script>`;
+  const candidate = extractJsonLdCandidate(html, source, "2026-08-28T21:00:00.000Z");
+  assert.equal(candidate.startDate, "2027-07-01");
+  assert.equal(candidate.endDate, "2027-07-03");
+  assert.equal(candidate.city, "Berlin");
+  assert.deepEqual(candidate.lineup, ["Band A", "Band B"]);
+  assert.equal(candidate.ticketsUrl, "https://tickets.example/fest");
+  assert.deepEqual(candidate.warnings, []);
+  assert.deepEqual(new Set(candidate.evidence.map(({ field }) => field)), new Set(["startDate", "endDate", "city", "lineup", "ticketsUrl"]));
+});
+
+test("JSON-LD extraction supports @graph and routes risky statuses to review", () => {
+  const html = `<script type='application/ld+json'>${JSON.stringify({
+    "@context": "https://schema.org",
+    "@graph": [
+      { "@type": "Organization", name: "Promoter" },
+      { "@type": ["Event", "MusicEvent"], startDate: "2027-08-05", eventStatus: "https://schema.org/EventCancelled" },
+    ],
+  })}</script>`;
+  const candidate = extractJsonLdCandidate(html, source, "2026-08-28T21:00:00.000Z");
+  assert.equal(candidate.startDate, "2027-08-05");
+  assert.ok(candidate.warnings.some((warning) => warning.includes("EventCancelled")));
+});
+
+test("missing or malformed JSON-LD returns a reviewable candidate", () => {
+  const malformed = extractJsonLdCandidate('<script type="application/ld+json">{broken}</script>', source, "2026-08-28T21:00:00.000Z");
+  assert.deepEqual(malformed.evidence, []);
+  assert.deepEqual(malformed.warnings, ["No JSON-LD Event was found"]);
+});

--- a/tests/ingestion-schedule.test.mjs
+++ b/tests/ingestion-schedule.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { dueFestivalSources, isSourceDue } from "../lib/ingestion/schedule.ts";
+
+const now = new Date("2026-08-28T21:00:00Z");
+const source = (refreshPolicy, lastSuccessfulCheck, enabled = true) => ({
+  festivalSlug: refreshPolicy, url: "https://example.com", strategies: ["json_ld_event"],
+  refreshPolicy, enabled, lastSuccessfulCheck,
+});
+
+test("sources without a successful check are due", () => {
+  assert.equal(isSourceDue(source("weekly"), now), true);
+});
+
+test("refresh intervals select only due sources", () => {
+  const sources = [
+    source("daily", "2026-08-27T20:59:59Z"),
+    source("every_3_days", "2026-08-27T20:59:59Z"),
+    source("weekly", "2026-08-21T20:59:59Z"),
+    source("archived", "2026-08-01T00:00:00Z"),
+    source("daily", "2026-08-01T00:00:00Z", false),
+  ];
+  assert.deepEqual(dueFestivalSources(sources, now).map(({ refreshPolicy }) => refreshPolicy), ["daily", "weekly"]);
+});
+
+test("invalid timestamps are retried", () => {
+  assert.equal(isSourceDue(source("daily", "not-a-date"), now), true);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "react-jsx",


### PR DESCRIPTION
Implements the first delivery slice of #1.

Included now:
- explicit source registry and adaptive refresh policy for all 50 festivals;
- versioned ingestion candidate/result contract with field provenance;
- normalized scalar and lineup diffing;
- safety policy that permits additive changes while routing removals, date changes, warnings, and empty lineup replacements to review;
- coverage and policy tests.

Next commits on this PR will add extraction adapters, persisted review artifacts, the CLI/workflow, and freshness/history UI.

Closes #1 only after all acceptance criteria in the issue comment are met.