### PR TITLE
Deploy the account API on a recoverable Next.js runtime

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,12 @@ jobs:
       - run: npm run typecheck
       - run: npm run test:data
       - run: npm run build
+        env:
+          DATABASE_URL: postgresql://build:build@127.0.0.1:5432/build
+          AUTH_SECRET: build-only-secret-that-is-never-used-at-runtime
+          APP_URL: https://festivals.kir-it.de
+      - name: Package standalone release
+        run: bash scripts/deploy/package-release.sh "$GITHUB_SHA" release.tar.gz
       - name: Configure SSH
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
@@ -47,13 +53,47 @@ jobs:
             StrictHostKeyChecking yes
           EOF
           chmod 600 ~/.ssh/config
-      - name: Deploy static export
-        run: rsync -rlptDz --delete out/ production:/
+      - name: Create protected runtime environment
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
+          APP_URL: ${{ secrets.APP_URL }}
+          SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
+          SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
+        run: |
+          for name in DATABASE_URL AUTH_SECRET APP_URL SPOTIFY_CLIENT_ID SPOTIFY_CLIENT_SECRET; do
+            test -n "${!name}" || { echo "Missing required production secret: $name" >&2; exit 1; }
+          done
+          umask 077
+          {
+            printf 'DATABASE_URL=%q\n' "$DATABASE_URL"
+            printf 'AUTH_SECRET=%q\n' "$AUTH_SECRET"
+            printf 'APP_URL=%q\n' "$APP_URL"
+            printf 'SPOTIFY_CLIENT_ID=%q\n' "$SPOTIFY_CLIENT_ID"
+            printf 'SPOTIFY_CLIENT_SECRET=%q\n' "$SPOTIFY_CLIENT_SECRET"
+            printf 'DEPLOYED_COMMIT=%q\n' "$GITHUB_SHA"
+          } > production.env
+      - name: Upload and activate release
+        run: |
+          scp release.tar.gz production.env scripts/deploy/install-release.sh production:/tmp/
+          ssh production bash /tmp/install-release.sh \
+            /tmp/release.tar.gz "$GITHUB_SHA" /tmp/production.env
+          ssh production rm -f /tmp/release.tar.gz /tmp/production.env /tmp/install-release.sh
       - name: Verify production
         run: |
           for attempt in {1..12}; do
-            if curl --fail --silent --show-error --retry 2 --max-time 20 \
-              https://festivals.kir-it.de/ | grep --quiet 'Festival Radar'; then
+            marker="$(curl --fail --silent --show-error --retry 2 --max-time 20 \
+              https://festivals.kir-it.de/api/health/deployment/)" || true
+            auth_status="$(curl --silent --output /tmp/auth.json --write-out '%{http_code}' \
+              --max-time 20 https://festivals.kir-it.de/api/auth/me/)" || true
+            if grep --fixed-strings --quiet "\"commit\":\"$GITHUB_SHA\"" <<<"$marker" \
+              && grep --fixed-strings --quiet '"database":"ok"' <<<"$marker" \
+              && test "$auth_status" = 401 \
+              && grep --quiet 'application/json' <(curl --silent --head https://festivals.kir-it.de/api/auth/me/) \
+              && curl --fail --silent --show-error --max-time 20 https://festivals.kir-it.de/ | grep --quiet 'Festival Radar' \
+              && curl --fail --silent --show-error --max-time 20 https://festivals.kir-it.de/planner/ >/dev/null \
+              && curl --fail --silent --show-error --max-time 20 https://festivals.kir-it.de/festivals/wacken-open-air/ >/dev/null \
+              && curl --fail --silent --show-error --max-time 20 https://festivals.kir-it.de/artists/iron-maiden/ >/dev/null; then
               exit 0
             fi
             sleep 5

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install
 npm run dev
 ```
 
-Production export:
+Production build:
 
 ```bash
 npm run typecheck
@@ -40,9 +40,26 @@ Authenticated users can connect Spotify at `/api/spotify/connect`; refresh
 tokens are encrypted at rest using `AUTH_SECRET`, and `/api/spotify/sync`
 imports their owned/followed playlists into the collections sync document.
 
-The deployable static site is written to `out/`. Festival seed data lives in
-`data/festivals.ts`. Official source availability and the setlist.fm API are
-checked automatically every three days by GitHub Actions.
+Production runs as a Next.js standalone server behind Apache, managed by
+systemd, with PostgreSQL-backed account APIs. The deploy workflow packages the
+exact `main` commit together with the supported Node.js 22 runtime, runs
+`prisma migrate deploy`, atomically switches the `/opt/festival-radar/current`
+symlink, and restores the previous release if the
+database-aware health check fails. The public deployed revision is available
+from `/api/health/deployment/`.
+
+The GitHub `production` environment must define `DEPLOY_HOST`, `DEPLOY_PORT`,
+`DEPLOY_SSH_KEY`, `DEPLOY_KNOWN_HOSTS`, `DATABASE_URL`, `AUTH_SECRET`, `APP_URL`,
+`SPOTIFY_CLIENT_ID`, and `SPOTIFY_CLIENT_SECRET`. Values are written to a
+root-owned mode-0600 environment file on the server and are never committed or
+printed. The configured SSH principal is root because the installer manages
+systemd and the Plesk Apache vhost include.
+The initial PostgreSQL database and role must exist before the first release;
+subsequent schema updates are applied by the checked-in Prisma migrations.
+
+Festival seed data lives in `data/festivals.ts`. Official source availability
+and the setlist.fm API are checked automatically every three days by GitHub
+Actions.
 
 Festival ingestion runs daily and selects sources according to their adaptive
 daily, three-day, weekly, or archived cadence. Run one source with

--- a/README.md
+++ b/README.md
@@ -54,8 +54,17 @@ The GitHub `production` environment must define `DEPLOY_HOST`, `DEPLOY_PORT`,
 root-owned mode-0600 environment file on the server and are never committed or
 printed. The configured SSH principal is root because the installer manages
 systemd and the Plesk Apache vhost include.
-The initial PostgreSQL database and role must exist before the first release;
-subsequent schema updates are applied by the checked-in Prisma migrations.
+Provision the initial least-privilege PostgreSQL database and role once on the
+server (the password is read only from the environment):
+
+```bash
+sudo FESTIVAL_DB_PASSWORD='<generated secret>' \
+  bash scripts/deploy/bootstrap-postgres.sh
+```
+
+Store the resulting connection string as the protected `DATABASE_URL` secret.
+The bootstrap is idempotent; subsequent schema updates are applied by the
+checked-in Prisma migrations.
 
 Festival seed data lives in `data/festivals.ts`. Official source availability
 and the setlist.fm API are checked automatically every three days by GitHub

--- a/app/api/health/deployment/route.ts
+++ b/app/api/health/deployment/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+import { db } from "@/lib/db";
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  try {
+    await db.$queryRaw`SELECT 1`;
+    return NextResponse.json({
+      status: "ok",
+      database: "ok",
+      commit: process.env.DEPLOYED_COMMIT || "development",
+    });
+  } catch {
+    return NextResponse.json(
+      {
+        status: "degraded",
+        database: "unavailable",
+        commit: process.env.DEPLOYED_COMMIT || "development",
+      },
+      { status: 503 },
+    );
+  }
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
 
 const nextConfig: NextConfig = {
+  output: "standalone",
   trailingSlash: true,
   basePath,
   assetPrefix: basePath || undefined,

--- a/scripts/deploy/bootstrap-postgres.sh
+++ b/scripts/deploy/bootstrap-postgres.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+database="${FESTIVAL_DB_NAME:-festival_radar}"
+role="${FESTIVAL_DB_USER:-festival_radar}"
+password="${FESTIVAL_DB_PASSWORD:?FESTIVAL_DB_PASSWORD is required}"
+
+[[ "$database" =~ ^[a-z_][a-z0-9_]*$ ]] || { echo "invalid database name" >&2; exit 2; }
+[[ "$role" =~ ^[a-z_][a-z0-9_]*$ ]] || { echo "invalid database role" >&2; exit 2; }
+(( ${#password} >= 24 )) || { echo "database password must contain at least 24 characters" >&2; exit 2; }
+
+sudo -u postgres psql --no-psqlrc --set=ON_ERROR_STOP=1 \
+  --set=role_name="$role" --set=role_password="$password" \
+  --set=database_name="$database" postgres <<'SQL'
+SELECT format('CREATE ROLE %I LOGIN PASSWORD %L', :'role_name', :'role_password')
+WHERE NOT EXISTS (SELECT FROM pg_roles WHERE rolname = :'role_name') \gexec
+SELECT format('ALTER ROLE %I LOGIN PASSWORD %L', :'role_name', :'role_password') \gexec
+SELECT format('CREATE DATABASE %I OWNER %I', :'database_name', :'role_name')
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = :'database_name') \gexec
+SELECT format('REVOKE ALL ON DATABASE %I FROM PUBLIC', :'database_name') \gexec
+SQL
+
+echo "PostgreSQL database and least-privilege application role are ready."

--- a/scripts/deploy/install-release.sh
+++ b/scripts/deploy/install-release.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+archive="${1:?usage: install-release.sh ARCHIVE COMMIT ENV_FILE}"
+commit="${2:?usage: install-release.sh ARCHIVE COMMIT ENV_FILE}"
+env_source="${3:?usage: install-release.sh ARCHIVE COMMIT ENV_FILE}"
+trap 'rm -f "$archive" "$env_source"' EXIT
+app_root="${APP_ROOT:-/opt/festival-radar}"
+service="${SERVICE_NAME:-festival-radar}"
+domain="${APP_DOMAIN:-festivals.kir-it.de}"
+port="${PORT:-3100}"
+release="$app_root/releases/$commit"
+shared="$app_root/shared"
+previous="$(readlink -f "$app_root/current" 2>/dev/null || true)"
+
+[[ "$commit" =~ ^[0-9a-f]{40}$ ]] || { echo "invalid commit" >&2; exit 2; }
+[[ "$app_root" == /opt/festival-radar ]] || { echo "unsupported APP_ROOT" >&2; exit 2; }
+test -s "$archive"
+test -s "$env_source"
+install -d -m 0755 "$app_root/releases" "$shared"
+install -m 0600 "$env_source" "$shared/production.env"
+
+rm -rf "$release"
+install -d -m 0755 "$release"
+tar -xzf "$archive" --strip-components=1 -C "$release"
+test "$(cat "$release/DEPLOYED_COMMIT")" = "$commit"
+
+cd "$release"
+npm ci --omit=dev --ignore-scripts --no-audit --no-fund
+set -a
+# shellcheck disable=SC1090
+source "$shared/production.env"
+set +a
+export DEPLOYED_COMMIT="$commit" PORT="$port" HOSTNAME=127.0.0.1
+"$release/.runtime/node" node_modules/prisma/build/index.js generate
+"$release/.runtime/node" node_modules/prisma/build/index.js migrate deploy
+
+cat > "/etc/systemd/system/$service.service" <<UNIT
+[Unit]
+Description=Festival Radar Next.js application
+After=network-online.target postgresql.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=www-data
+Group=www-data
+WorkingDirectory=$app_root/current
+EnvironmentFile=$shared/production.env
+Environment=NODE_ENV=production
+Environment=PORT=$port
+Environment=HOSTNAME=127.0.0.1
+ExecStart=$app_root/current/.runtime/node server.js
+Restart=on-failure
+RestartSec=5
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ReadWritePaths=$app_root
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+vhost="/var/www/vhosts/system/$domain/conf/vhost.conf"
+install -d -m 0755 "$(dirname "$vhost")"
+cat > "$vhost" <<APACHE
+ProxyPreserveHost On
+ProxyPass / http://127.0.0.1:$port/
+ProxyPassReverse / http://127.0.0.1:$port/
+RequestHeader set X-Forwarded-Proto "https" env=HTTPS
+APACHE
+
+ln -sfn "$release" "$app_root/current"
+chown -R www-data:www-data "$release" "$shared"
+systemctl daemon-reload
+systemctl enable --now "$service"
+if command -v plesk >/dev/null 2>&1; then
+  plesk bin httpdmng --reconfigure-domain "$domain"
+else
+  apache2ctl configtest
+  systemctl reload apache2
+fi
+
+healthy=false
+for _ in $(seq 1 20); do
+  if response="$(curl --fail --silent --show-error --max-time 5 "http://127.0.0.1:$port/api/health/deployment/")" \
+    && grep -Fq "\"commit\":\"$commit\"" <<<"$response" \
+    && grep -Fq '"database":"ok"' <<<"$response"; then
+    healthy=true
+    break
+  fi
+  sleep 2
+done
+
+if [[ "$healthy" != true ]]; then
+  if [[ -n "$previous" && -d "$previous" ]]; then
+    ln -sfn "$previous" "$app_root/current"
+    systemctl restart "$service"
+  fi
+  echo "release health check failed; previous release restored" >&2
+  exit 1
+fi
+
+find "$app_root/releases" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\n' \
+  | sort -nr | awk 'NR > 5 { sub(/^[^ ]+ /, ""); print }' \
+  | xargs -r rm -rf --

--- a/scripts/deploy/package-release.sh
+++ b/scripts/deploy/package-release.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit="${1:?usage: package-release.sh COMMIT [OUTPUT]}"
+output="${2:-festival-radar-${commit}.tar.gz}"
+stage="$(mktemp -d)"
+trap 'rm -rf "$stage"' EXIT
+
+test -f .next/standalone/server.js
+mkdir -p "$stage/app/.next" "$stage/app/.runtime"
+cp "$(command -v node)" "$stage/app/.runtime/node"
+chmod 0755 "$stage/app/.runtime/node"
+cp -a .next/standalone/. "$stage/app/"
+cp -a .next/static "$stage/app/.next/static"
+cp -a public "$stage/app/public"
+cp package.json package-lock.json "$stage/app/"
+cp -a prisma "$stage/app/prisma"
+printf '%s\n' "$commit" > "$stage/app/DEPLOYED_COMMIT"
+tar -C "$stage" -czf "$output" app
+tar -tzf "$output" >/dev/null


### PR DESCRIPTION
## Summary
- deploy Next.js standalone with a bundled Node.js 22 runtime instead of static `out/`
- run Prisma migrations before an atomic systemd release switch with health-based rollback
- proxy the application through the production Apache/Plesk vhost
- expose a database-aware deployed-commit marker and verify API/static routes
- document required protected production secrets and operational layout

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm run test:data` (17 passed)
- `npm test` (53 passed)
- `npm run build`
- release archive integrity and bundled Node v22.23.2
- standalone smoke: homepage 200, `/api/auth/me/` JSON 401, health marker reports the exact commit and expected 503 with deliberately unavailable test DB
- deploy workflow YAML parsed successfully

## Production rollout
The branch does not mutate production. On merge, the protected deployment requires the documented database/OAuth/auth secrets; the installer then runs `prisma migrate deploy`, activates atomically, and verifies the exact main SHA.

Closes #37