### PR TITLE
Enforce server-side administration authorization

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,9 +1,14 @@
 import { AdminConsole } from "@/components/AdminConsole";
 import { festivals } from "@/data/festivals";
 import { auditEntries, parserRuns, reviewChanges } from "@/lib/admin";
+import { currentUser } from "@/lib/auth";
+import { forbidden, redirect } from "next/navigation";
 
 export const metadata = { title: "Administration | Festival Radar" };
 
-export default function AdminPage() {
-  return <AdminConsole festivals={festivals} initialChanges={reviewChanges} parserRuns={parserRuns} auditEntries={auditEntries} />;
+export default async function AdminPage() {
+  const actor = await currentUser();
+  if (!actor) redirect("/?login=required&next=/admin");
+  if (actor.role !== "EDITOR" && actor.role !== "ADMIN") forbidden();
+  return <AdminConsole actor={{ email: actor.email, role: actor.role }} festivals={festivals} initialChanges={reviewChanges} parserRuns={parserRuns} auditEntries={auditEntries} />;
 }

--- a/app/api/admin/actions/route.ts
+++ b/app/api/admin/actions/route.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import { requireAdminActor, rejectUntrustedOrigin } from "@/lib/admin-auth";
+import { error } from "@/lib/api";
+import { db } from "@/lib/db";
+
+const input = z.discriminatedUnion("action", [
+  z.object({ action: z.literal("review.decide"), target: z.string().min(1).max(100), decision: z.enum(["approved", "rejected"]) }),
+  z.object({ action: z.literal("festival.save-draft"), target: z.string().min(1).max(100) }),
+  z.object({ action: z.literal("festival.refresh"), target: z.string().min(1).max(100) }),
+]);
+
+export async function POST(request: Request) {
+  const originError = rejectUntrustedOrigin(request);
+  if (originError) return originError;
+  const parsed = input.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) return error("Invalid administrative action.", 400);
+  const allowed = parsed.data.action === "festival.refresh" ? ["ADMIN"] as const : ["EDITOR", "ADMIN"] as const;
+  const auth = await requireAdminActor(allowed);
+  if (auth.response) return auth.response;
+  const entry = await db.adminAuditEntry.create({ data: {
+    actorId: auth.actor.id, action: parsed.data.action, target: parsed.data.target,
+    detail: "decision" in parsed.data ? { decision: parsed.data.decision } : undefined,
+  } });
+  return Response.json({ accepted: true, auditId: entry.id }, { status: 202, headers: { "Cache-Control": "no-store" } });
+}

--- a/app/api/admin/route.ts
+++ b/app/api/admin/route.ts
@@ -1,0 +1,19 @@
+import { festivals } from "@/data/festivals";
+import { auditEntries, parserRuns, reviewChanges } from "@/lib/admin";
+import { requireAdminActor } from "@/lib/admin-auth";
+import { db } from "@/lib/db";
+
+export async function GET() {
+  const auth = await requireAdminActor();
+  if (auth.response) return auth.response;
+  const persistedAudit = await db.adminAuditEntry.findMany({
+    orderBy: { createdAt: "desc" }, take: 100, include: { actor: { select: { email: true } } },
+  });
+  return Response.json({
+    actor: { email: auth.actor.email, role: auth.actor.role }, festivals, reviewChanges, parserRuns,
+    auditEntries: [
+      ...persistedAudit.map((entry) => ({ id: entry.id, at: entry.createdAt.toISOString(), actor: entry.actor.email, action: entry.action, target: entry.target, detail: JSON.stringify(entry.detail ?? {}) })),
+      ...auditEntries,
+    ],
+  }, { headers: { "Cache-Control": "private, no-store" } });
+}

--- a/components/AdminConsole.tsx
+++ b/components/AdminConsole.tsx
@@ -6,7 +6,7 @@ import type { AuditEntry, ParserRun, ReviewChange } from "@/lib/admin";
 
 type Section = "content" | "review" | "assets" | "diagnostics" | "audit";
 
-export function AdminConsole({ festivals, initialChanges, parserRuns, auditEntries }: { festivals: Festival[]; initialChanges: ReviewChange[]; parserRuns: ParserRun[]; auditEntries: AuditEntry[] }) {
+export function AdminConsole({ actor, festivals, initialChanges, parserRuns, auditEntries }: { actor: { email: string; role: "EDITOR" | "ADMIN" }; festivals: Festival[]; initialChanges: ReviewChange[]; parserRuns: ParserRun[]; auditEntries: AuditEntry[] }) {
   const [section, setSection] = useState<Section>("review");
   const [selectedSlug, setSelectedSlug] = useState(festivals[0]?.slug ?? "");
   const selected = festivals.find((item) => item.slug === selectedSlug) ?? festivals[0];
@@ -16,14 +16,22 @@ export function AdminConsole({ festivals, initialChanges, parserRuns, auditEntri
   const [artistQuery, setArtistQuery] = useState("");
   const artists = useMemo(() => Array.from(new Set(festivals.flatMap((item) => [...item.headliners, ...item.lineup]))).filter((artist) => artist.toLowerCase().includes(artistQuery.toLowerCase())).slice(0, 12), [festivals, artistQuery]);
 
-  const decide = (id: string, status: "approved" | "rejected") => {
+  const runAction = async (body: Record<string, string>) => {
+    const response = await fetch("/api/admin/actions", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
+    if (!response.ok) throw new Error((await response.json().catch(() => null))?.error ?? "Administrative action failed.");
+  };
+  const decide = async (id: string, status: "approved" | "rejected") => {
+    try { await runAction({ action: "review.decide", target: id, decision: status }); }
+    catch (cause) { setNotice(cause instanceof Error ? cause.message : "Administrative action failed."); return; }
     setChanges((items) => items.map((item) => item.id === id ? { ...item, status } : item));
     setNotice(`Change ${id} ${status}. The decision was added to the audit trail.`);
   };
-  const refresh = () => {
+  const refresh = async () => {
     setRefreshing(true);
     setNotice("");
-    window.setTimeout(() => { setRefreshing(false); setNotice(`${selected.name} refresh finished. One review item was queued; publication remains gated.`); }, 700);
+    try { await runAction({ action: "festival.refresh", target: selected.slug }); setNotice(`${selected.name} refresh was accepted and recorded in the audit trail.`); }
+    catch (cause) { setNotice(cause instanceof Error ? cause.message : "Refresh failed."); }
+    finally { setRefreshing(false); }
   };
 
   return <main className="adminShell">
@@ -33,7 +41,7 @@ export function AdminConsole({ festivals, initialChanges, parserRuns, auditEntri
       <a href="/">← Public site</a>
     </aside>
     <section className="adminMain">
-      <header className="adminHeader"><div><div className="eyebrow">Operations / 2027 season</div><h2>{section === "review" ? "Detected changes" : section === "content" ? "Content editor" : section === "assets" ? "Links & assets" : section === "diagnostics" ? "Parser diagnostics" : "Audit history"}</h2></div><span className="adminRole">Editor · Review required</span></header>
+      <header className="adminHeader"><div><div className="eyebrow">Operations / 2027 season</div><h2>{section === "review" ? "Detected changes" : section === "content" ? "Content editor" : section === "assets" ? "Links & assets" : section === "diagnostics" ? "Parser diagnostics" : "Audit history"}</h2></div><span className="adminRole">{actor.role} · {actor.email}</span></header>
       {notice && <div className="adminNotice" role="status">{notice}<button onClick={() => setNotice("")} aria-label="Dismiss">×</button></div>}
 
       {section === "review" && <div className="reviewList">
@@ -47,7 +55,7 @@ export function AdminConsole({ festivals, initialChanges, parserRuns, auditEntri
       </div>}
 
       {section === "content" && selected && <div className="editorGrid">
-        <div className="adminPanel"><label>Festival<select value={selectedSlug} onChange={(event) => setSelectedSlug(event.target.value)}>{festivals.map((item) => <option value={item.slug} key={item.slug}>{item.name}</option>)}</select></label><div className="fieldPair"><label>Name<input defaultValue={selected.name}/></label><label>Status<select defaultValue={selected.status}><option>confirmed</option><option>partial</option><option>tba</option></select></label></div><div className="fieldPair"><label>City<input defaultValue={selected.city}/></label><label>Country<input defaultValue={selected.country}/></label></div><div className="fieldPair"><label>Start date<input type="date" defaultValue={selected.startDate}/></label><label>End date<input type="date" defaultValue={selected.endDate}/></label></div><label>Headliners<textarea defaultValue={selected.headliners.join("\n")} rows={5}/></label><button onClick={() => setNotice("Draft saved. It will not be published until reviewed.")}>Save festival draft</button></div>
+        <div className="adminPanel"><label>Festival<select value={selectedSlug} onChange={(event) => setSelectedSlug(event.target.value)}>{festivals.map((item) => <option value={item.slug} key={item.slug}>{item.name}</option>)}</select></label><div className="fieldPair"><label>Name<input defaultValue={selected.name}/></label><label>Status<select defaultValue={selected.status}><option>confirmed</option><option>partial</option><option>tba</option></select></label></div><div className="fieldPair"><label>City<input defaultValue={selected.city}/></label><label>Country<input defaultValue={selected.country}/></label></div><div className="fieldPair"><label>Start date<input type="date" defaultValue={selected.startDate}/></label><label>End date<input type="date" defaultValue={selected.endDate}/></label></div><label>Headliners<textarea defaultValue={selected.headliners.join("\n")} rows={5}/></label><button onClick={async () => { try { await runAction({ action: "festival.save-draft", target: selected.slug }); setNotice("Draft saved and attributed in the audit trail. It will not be published until reviewed."); } catch (cause) { setNotice(cause instanceof Error ? cause.message : "Save failed."); } }}>Save festival draft</button></div>
         <div><div className="adminPanel"><h3>Manual refresh</h3><p>Run only this festival’s configured adapters. Any differences go to the review queue.</p><button onClick={refresh} disabled={refreshing}>{refreshing ? "Refreshing…" : `Refresh ${selected.name}`}</button></div><div className="adminPanel"><h3>Artist editor</h3><input placeholder="Find an artist" value={artistQuery} onChange={(event) => setArtistQuery(event.target.value)}/><ul className="artistAdminList">{artists.map((artist) => <li key={artist}><span>{artist}</span><button className="textButton" onClick={() => setNotice(`${artist} opened for canonical identity and link editing.`)}>Edit</button></li>)}</ul></div></div>
       </div>}
 

--- a/docs/admin-access.md
+++ b/docs/admin-access.md
@@ -1,0 +1,13 @@
+# Administrative access
+
+Administrative access is deny-by-default. New accounts receive `USER`; `EDITOR` may read the console, review changes, and save drafts, while only `ADMIN` may trigger refresh operations. Both the page and API enforce roles server-side. Mutations additionally require a same-origin `Origin` header, and every accepted mutation records the authenticated session user in `AdminAuditEntry`.
+
+Role assignment is an operator-only database operation. From a trusted deployment shell with `DATABASE_URL` configured, run:
+
+```sh
+npm run admin:assign-role -- editor@example.com EDITOR --confirm
+```
+
+Use `USER` to revoke access. Review the target email and requested role before confirmation. The application exposes no public role-assignment endpoint.
+
+After deployment, smoke-test `/admin` and `/api/admin` as anonymous, ordinary-user, editor, and administrator accounts. Anonymous API requests must return 401, ordinary users 403, editors must be denied refresh with 403, and administrators must receive 202 for same-origin mutations. Cross-origin mutation requests must return 403 for every role.

--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -1,0 +1,36 @@
+import type { UserRole } from "@prisma/client";
+import { currentUser } from "@/lib/auth";
+import { error } from "@/lib/api";
+
+export type AdminActor = { id: string; email: string; role: UserRole };
+export const ADMIN_ROLES: readonly UserRole[] = ["EDITOR", "ADMIN"];
+
+export function roleAllowed(role: UserRole, allowed: readonly UserRole[] = ADMIN_ROLES) {
+  return allowed.includes(role);
+}
+
+export function accessStatus(role: UserRole | null, allowed: readonly UserRole[] = ADMIN_ROLES) {
+  if (!role) return 401;
+  return roleAllowed(role, allowed) ? 200 : 403;
+}
+
+export async function requireAdminActor(allowed: readonly UserRole[] = ADMIN_ROLES): Promise<
+  { response: Response; actor: null } | { response: null; actor: AdminActor }
+> {
+  const actor = await currentUser();
+  const status = accessStatus(actor?.role ?? null, allowed);
+  if (status === 401) return { response: error("Authentication required.", 401), actor: null };
+  if (status === 403) return { response: error("Administrator role required.", 403), actor: null };
+  return { response: null, actor: actor as AdminActor };
+}
+
+export function requestHasTrustedOrigin(request: Request, configuredAppUrl = process.env.APP_URL) {
+  const origin = request.headers.get("origin");
+  if (!origin) return false;
+  const expected = configuredAppUrl ? new URL(configuredAppUrl).origin : new URL(request.url).origin;
+  return origin === expected;
+}
+
+export function rejectUntrustedOrigin(request: Request) {
+  return requestHasTrustedOrigin(request) ? null : error("Untrusted request origin.", 403);
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -22,7 +22,7 @@ export async function currentUser() {
   if (!token) return null;
   const session = await db.session.findUnique({ where: { tokenHash: digest(token) }, include: { user: true } });
   if (!session || session.expiresAt <= new Date()) return null;
-  return { id: session.user.id, email: session.user.email };
+  return { id: session.user.id, email: session.user.email, role: session.user.role };
 }
 
 export async function destroySession() {

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 const basePath = process.env.NEXT_PUBLIC_BASE_PATH || "";
 
 const nextConfig: NextConfig = {
+  experimental: { authInterrupts: true },
   trailingSlash: true,
   basePath,
   assetPrefix: basePath || undefined,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,9 @@
         "react-dom": "^19.0.0",
         "typescript": "^5.7.0",
         "zod": "^4.1.12"
+      },
+      "devDependencies": {
+        "tsx": "^4.20.5"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -28,6 +31,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@img/colour": {
@@ -968,6 +1413,48 @@
         "node": ">=14"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
@@ -994,6 +1481,21 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/giget": {
@@ -1394,6 +1896,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "ingest": "node scripts/ingest-festivals.mjs",
     "test:data": "node --test tests/*.test.mjs",
     "playlists:status": "node scripts/build-playlist-status.mjs",
-    "test": "python3 -m unittest discover -s tests"
+    "test": "python3 -m unittest discover -s tests",
+    "test:admin-auth": "node --import tsx --test tests/admin-auth.test.ts",
+    "admin:assign-role": "node scripts/assign-admin-role.mjs"
   },
   "dependencies": {
     "@prisma/client": "^6.19.0",
@@ -26,5 +28,6 @@
     "react-dom": "^19.0.0",
     "typescript": "^5.7.0",
     "zod": "^4.1.12"
-  }
+  },
+  "devDependencies": { "tsx": "^4.20.5" }
 }

--- a/prisma/migrations/20260829115200_admin_authorization/migration.sql
+++ b/prisma/migrations/20260829115200_admin_authorization/migration.sql
@@ -1,0 +1,17 @@
+CREATE TYPE "UserRole" AS ENUM ('USER', 'EDITOR', 'ADMIN');
+
+ALTER TABLE "User" ADD COLUMN "role" "UserRole" NOT NULL DEFAULT 'USER';
+
+CREATE TABLE "AdminAuditEntry" (
+    "id" TEXT NOT NULL,
+    "actorId" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "target" TEXT NOT NULL,
+    "detail" JSONB,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "AdminAuditEntry_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "AdminAuditEntry_createdAt_idx" ON "AdminAuditEntry"("createdAt");
+CREATE INDEX "AdminAuditEntry_actorId_createdAt_idx" ON "AdminAuditEntry"("actorId", "createdAt");
+ALTER TABLE "AdminAuditEntry" ADD CONSTRAINT "AdminAuditEntry_actorId_fkey" FOREIGN KEY ("actorId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -43,12 +43,19 @@ enum NotificationStatus {
   SKIPPED
 }
 
+enum UserRole {
+  USER
+  EDITOR
+  ADMIN
+}
+
 model User {
   id                        String                     @id @default(cuid())
   email                     String                     @unique
   passwordHash              String
   createdAt                 DateTime                   @default(now())
   updatedAt                 DateTime                   @updatedAt
+  role                      UserRole                   @default(USER)
   sessions                  Session[]
   documents                 SyncDocument[]
   shareLinks                ShareLink[]
@@ -56,6 +63,20 @@ model User {
   notificationPreferences   NotificationPreference[]
   notificationSubscriptions NotificationSubscription[]
   notificationDeliveries    NotificationDelivery[]
+  adminAuditEntries         AdminAuditEntry[]
+}
+
+model AdminAuditEntry {
+  id        String   @id @default(cuid())
+  actorId   String
+  action    String
+  target    String
+  detail    Json?
+  createdAt DateTime @default(now())
+  actor     User     @relation(fields: [actorId], references: [id], onDelete: Restrict)
+
+  @@index([createdAt])
+  @@index([actorId, createdAt])
 }
 
 model NotificationPreference {

--- a/scripts/assign-admin-role.mjs
+++ b/scripts/assign-admin-role.mjs
@@ -1,0 +1,14 @@
+import { PrismaClient } from "@prisma/client";
+
+const [emailArg, roleArg, confirmation] = process.argv.slice(2);
+const email = emailArg?.trim().toLowerCase();
+const role = roleArg?.toUpperCase();
+if (!email || !["USER", "EDITOR", "ADMIN"].includes(role) || confirmation !== "--confirm") {
+  console.error("Usage: npm run admin:assign-role -- user@example.com USER|EDITOR|ADMIN --confirm");
+  process.exit(2);
+}
+const db = new PrismaClient();
+try {
+  const user = await db.user.update({ where: { email }, data: { role }, select: { id: true, email: true, role: true } });
+  console.log(`Role updated for ${user.email}: ${user.role}`);
+} finally { await db.$disconnect(); }

--- a/tests/admin-auth.test.ts
+++ b/tests/admin-auth.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { accessStatus, requestHasTrustedOrigin, roleAllowed } from "../lib/admin-auth.ts";
+
+test("ordinary users are denied while editors and administrators are allowed", () => {
+  assert.equal(accessStatus(null), 401);
+  assert.equal(accessStatus("USER"), 403);
+  assert.equal(accessStatus("EDITOR"), 200);
+  assert.equal(accessStatus("ADMIN"), 200);
+  assert.equal(roleAllowed("USER"), false);
+  assert.equal(roleAllowed("EDITOR"), true);
+  assert.equal(roleAllowed("ADMIN"), true);
+  assert.equal(roleAllowed("EDITOR", ["ADMIN"]), false);
+  assert.equal(roleAllowed("ADMIN", ["ADMIN"]), true);
+  assert.equal(accessStatus("EDITOR", ["ADMIN"]), 403);
+});
+
+test("administrative mutations require the configured same origin", () => {
+  const same = new Request("https://radar.example/api/admin/actions", { headers: { origin: "https://radar.example" } });
+  const forged = new Request("https://radar.example/api/admin/actions", { headers: { origin: "https://evil.example" } });
+  const missing = new Request("https://radar.example/api/admin/actions");
+  assert.equal(requestHasTrustedOrigin(same, "https://radar.example"), true);
+  assert.equal(requestHasTrustedOrigin(forged, "https://radar.example"), false);
+  assert.equal(requestHasTrustedOrigin(missing, "https://radar.example"), false);
+});


### PR DESCRIPTION
Closes #45

## Summary
- add deny-by-default USER/EDITOR/ADMIN roles and an operator-only assignment command
- enforce session/role checks on the admin page and all admin APIs
- protect mutations with same-origin validation and persist authenticated audit actors
- add authorization tests, migration, operational docs, and runtime smoke evidence

## Verification
- git diff --check
- Prisma format + validate
- npm run test:admin-auth (2/2)
- npm run typecheck
- npm run test:data (17/17)
- npm test (53/53)
- npm run build
- production build smoke: anonymous /admin -> login redirect; anonymous /api/admin -> 401; forged-origin mutation -> 403

## Deployment note
After merge/migration, an operator must explicitly assign the first EDITOR/ADMIN role as documented in docs/admin-access.md. Production role-boundary smoke testing remains dependent on deployment and test accounts.