### PR TITLE
Prevent false-positive lineup extraction across festival editions

### DIFF
--- a/data/festival-sources.ts
+++ b/data/festival-sources.ts
@@ -2,10 +2,11 @@ import { festivals } from "./festivals.ts";
 import type { FestivalSource, ParserStrategy, RefreshPolicy } from "../lib/ingestion/types.ts";
 
 const bySlug = new Map(festivals.map((festival) => [festival.slug, festival]));
+const catalogueEditionYear = 2027;
 function source(festivalSlug: string, refreshPolicy: RefreshPolicy, strategies: ParserStrategy[] = ["json_ld_event", "html_fallback"]): FestivalSource {
   const festival = bySlug.get(festivalSlug);
   if (!festival) throw new Error(`Unknown festival source: ${festivalSlug}`);
-  return { festivalSlug, url: festival.officialUrl, strategies, refreshPolicy, enabled: true };
+  return { festivalSlug, url: festival.officialUrl, strategies, refreshPolicy, enabled: true, editionYear: festival.startDate ? Number(festival.startDate.slice(0, 4)) : catalogueEditionYear };
 }
 
 // Explicit inventory: adding a festival to the catalogue requires adding its source here.

--- a/lib/ingestion/adapters/html-fallback.ts
+++ b/lib/ingestion/adapters/html-fallback.ts
@@ -1,5 +1,6 @@
 import type { FestivalCandidate, FestivalSource, FieldEvidence } from "../types.ts";
 import { INGESTION_SCHEMA_VERSION } from "../types.ts";
+import { validateGenericLineup } from "../lineup-quality.ts";
 
 type SupportedField = FieldEvidence["field"];
 
@@ -68,25 +69,29 @@ function ticketLink(html: string, sourceUrl: string): { value: string; excerpt: 
   return undefined;
 }
 
-function markedNames(html: string): { values: string[]; excerpt: string } | undefined {
+function markedNames(html: string): { values: string[]; excerpt: string; warnings: string[] } | undefined {
   const values: string[] = [];
+  const combinedFlags: boolean[] = [];
   let excerpt = "";
   const pattern = /<([a-z][\w:-]*)\b([^>]*(?:data-artist|itemprop\s*=\s*["']performer["']|class\s*=\s*["'][^"']*(?:artist|lineup)[^"']*["'])[^>]*)>([\s\S]*?)<\/\1>/gi;
   for (const match of html.matchAll(pattern)) {
     const attrs = attributes(`<${match[1]} ${match[2]}>`);
-    const value = decode(attrs.get("data-artist") ?? match[3].replace(/<[^>]+>/g, " "));
-    if (value && value.length <= 120 && !/^(line-?up|artists?|performers?)$/i.test(value)) {
+    const inner = match[3];
+    const value = decode(attrs.get("data-artist") ?? inner.replace(/<[^>]+>/g, " "));
+    if (value) {
       values.push(value);
+      combinedFlags.push(!attrs.has("data-artist") && /<br\b|<li\b|data-artist|itemprop\s*=\s*["']performer/iu.test(inner));
       if (!excerpt) excerpt = match[0].slice(0, 500);
     }
   }
+  const quality = validateGenericLineup(values, combinedFlags);
   const byNormalizedName = new Map<string, string>();
-  for (const value of values) {
+  for (const value of quality.names) {
     const normalized = value.toLocaleLowerCase();
     if (!byNormalizedName.has(normalized)) byNormalizedName.set(normalized, value);
   }
   const unique = [...byNormalizedName.values()];
-  return unique.length ? { values: unique, excerpt } : undefined;
+  return unique.length || quality.warnings.length ? { values: unique, excerpt, warnings: quality.warnings } : undefined;
 }
 
 export function extractHtmlFallbackCandidate(html: string, source: FestivalSource, fetchedAt: string): FestivalCandidate {
@@ -97,6 +102,7 @@ export function extractHtmlFallbackCandidate(html: string, source: FestivalSourc
     fetchedAt,
     evidence: [],
     warnings: [],
+    observedEditionYears: [],
   };
   const start = metaContent(html, ["event:start_time", "event:start_date", "festival:start_date"]) ?? timeValue(html, "start");
   const end = metaContent(html, ["event:end_time", "event:end_date", "festival:end_date"]) ?? timeValue(html, "end");
@@ -114,6 +120,10 @@ export function extractHtmlFallbackCandidate(html: string, source: FestivalSourc
   add("city", city?.value, city?.excerpt);
   add("ticketsUrl", tickets?.value, tickets?.excerpt);
   add("lineup", lineup?.values, lineup?.excerpt);
+  if (start?.value) candidate.observedEditionYears.push(Number(plainDate(start.value)?.slice(0, 4)));
+  if (end?.value) candidate.observedEditionYears.push(Number(plainDate(end.value)?.slice(0, 4)));
+  candidate.observedEditionYears = [...new Set(candidate.observedEditionYears.filter(Number.isFinite))];
+  candidate.warnings.push(...(lineup?.warnings ?? []));
 
   if (candidate.evidence.length === 0) candidate.warnings.push("HTML fallback did not find explicitly marked festival fields");
   return candidate;

--- a/lib/ingestion/adapters/json-ld.ts
+++ b/lib/ingestion/adapters/json-ld.ts
@@ -1,5 +1,6 @@
 import type { FestivalCandidate, FestivalSource, FieldEvidence } from "../types.ts";
 import { INGESTION_SCHEMA_VERSION } from "../types.ts";
+import { validateGenericLineup } from "../lineup-quality.ts";
 
 type JsonLd = Record<string, unknown>;
 
@@ -75,7 +76,8 @@ function ticketUrl(offers: unknown): string | undefined {
 
 export function extractJsonLdCandidate(html: string, source: FestivalSource, fetchedAt: string): FestivalCandidate {
   const matches = eventRecords(html);
-  const selected = matches[0];
+  const matching = matches.filter(({ event }) => date(event.startDate)?.startsWith(`${source.editionYear}-`));
+  const selected = matching[0] ?? matches[0];
   const candidate: FestivalCandidate = {
     schemaVersion: INGESTION_SCHEMA_VERSION,
     festivalSlug: source.festivalSlug,
@@ -83,6 +85,7 @@ export function extractJsonLdCandidate(html: string, source: FestivalSource, fet
     fetchedAt,
     evidence: [],
     warnings: [],
+    observedEditionYears: [],
   };
 
   if (!selected) {
@@ -97,6 +100,14 @@ export function extractJsonLdCandidate(html: string, source: FestivalSource, fet
     lineup: names(selected.event.performer),
     ticketsUrl: ticketUrl(selected.event.offers),
   };
+  const lineupQuality = validateGenericLineup(fields.lineup ?? []);
+  fields.lineup = lineupQuality.names.length ? lineupQuality.names : fields.lineup === undefined ? undefined : [];
+  candidate.warnings.push(...lineupQuality.warnings);
+  const observedYear = Number(date(selected.event.startDate)?.slice(0, 4));
+  if (Number.isFinite(observedYear)) candidate.observedEditionYears.push(observedYear);
+  if (matches.length && matching.length === 0 && candidate.observedEditionYears.length) {
+    candidate.warnings.push(`JSON-LD event edition ${candidate.observedEditionYears[0]} does not match catalogue edition ${source.editionYear}`);
+  }
 
   for (const [field, value] of Object.entries(fields)) {
     if (value === undefined) continue;
@@ -108,7 +119,7 @@ export function extractJsonLdCandidate(html: string, source: FestivalSource, fet
   if (eventStatus?.includes("cancelled") || eventStatus?.includes("postponed")) {
     candidate.warnings.push(`Official event status requires review: ${text(selected.event.eventStatus)}`);
   }
-  if (matches.length > 1) candidate.warnings.push(`Multiple JSON-LD Events found (${matches.length}); the first event was selected`);
+  if (matching.length > 1) candidate.warnings.push(`Multiple JSON-LD Events match catalogue edition ${source.editionYear} (${matching.length}); the first matching event was selected`);
   if (candidate.evidence.length === 0) candidate.warnings.push("JSON-LD Event did not contain supported festival fields");
   return candidate;
 }

--- a/lib/ingestion/extract.ts
+++ b/lib/ingestion/extract.ts
@@ -18,15 +18,19 @@ export function extractFestivalCandidate(html: string, source: FestivalSource, f
     fetchedAt,
     evidence: [],
     warnings: [],
+    observedEditionYears: [],
   };
   for (const candidate of candidates) {
     for (const field of supportedFields) {
       if (merged[field] === undefined && candidate[field] !== undefined) Object.assign(merged, { [field]: candidate[field] });
     }
     merged.evidence.push(...candidate.evidence.filter(({ field }) => merged[field] !== undefined));
+    merged.observedEditionYears.push(...candidate.observedEditionYears);
+    merged.warnings.push(...candidate.warnings);
   }
   const hasEvidence = new Set(merged.evidence.map(({ field }) => field));
   merged.evidence = merged.evidence.filter(({ field }, index, values) => values.findIndex((evidence) => evidence.field === field) === index);
-  if (hasEvidence.size === 0) merged.warnings = [...new Set(candidates.flatMap(({ warnings }) => warnings))];
+  merged.observedEditionYears = [...new Set(merged.observedEditionYears)];
+  merged.warnings = [...new Set(merged.warnings)];
   return merged;
 }

--- a/lib/ingestion/lineup-quality.ts
+++ b/lib/ingestion/lineup-quality.ts
@@ -1,0 +1,38 @@
+export type LineupQuality = {
+  names: string[];
+  warnings: string[];
+};
+
+const navigationLabel = /^(?:artists?|artistas?|artistes?|artyst(?:a|i)|artyści|line[ -]?up(?:\s+\d+)?|performers?|program(?:me|a)?|bands?|more|menu|home|news|tickets?)\s*[,.:;!\-]*$/iu;
+const dateOrSchedule = /(?:\b(?:mon|tue|wed|thu|fri|sat|sun|monday|tuesday|wednesday|thursday|friday|saturday|sunday|lun|mar|mer|jeu|ven|sam|dim|lunes|martes|miércoles|jueves|viernes|sábado|domingo|juillet|juni|june|july|août|agosto|julio)\b|\b\d{1,2}[.:]\d{2}\b|\b\d{1,2}\s*[-–]\s*\d{1,2}\s+(?:july|juillet|julio|august|août|agosto)\b|\b(?:stage|scène|bühne|escenario)\b|\b(?:days?|hours?|minutes?|seconds?|tage|stunden|minuten|sekunden)\s*(?:left|remaining)?\b)/iu;
+const trailingDate = /\s*(?:[-–—|,]\s*)?(?:(?:mon|tue|wed|thu|fri|sat|sun)(?:day)?|(?:lun|mar|mer|jeu|ven|sam|dim)(?:di)?|lundi|mardi|mercredi|jeudi|vendredi|samedi|dimanche)\s+\d{1,2}(?:st|nd|rd|th)?\s+(?:january|february|march|april|may|june|july|august|september|october|november|december|janvier|février|mars|avril|mai|juin|juillet|août|septembre|octobre|novembre|décembre|enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|octubre|noviembre|diciembre)(?:\s+20\d{2})?\s*$/iu;
+
+function normalize(value: string): string {
+  return value.replace(/\u00a0/g, " ").replace(/\s+/g, " ").replace(trailingDate, "").replace(/\s*[-–—|,]\s*$/, "").trim();
+}
+
+export function validateGenericLineup(values: string[], combinedFlags: boolean[] = []): LineupQuality {
+  const names: string[] = [];
+  const warnings = new Set<string>();
+  for (const [index, raw] of values.entries()) {
+    const name = normalize(raw);
+    if (!name || navigationLabel.test(name)) {
+      warnings.add(`Rejected lineup navigation label: ${raw.trim() || "(empty)"}`);
+      continue;
+    }
+    if (dateOrSchedule.test(name)) {
+      warnings.add(`Rejected lineup schedule/date/stage text: ${raw.trim()}`);
+      continue;
+    }
+    if (combinedFlags[index]) {
+      warnings.add(`Combined artist block requires a festival-specific trusted adapter: ${name.slice(0, 120)}`);
+      continue;
+    }
+    if (name.length > 100) {
+      warnings.add(`Ambiguous long lineup container requires review: ${name.slice(0, 120)}`);
+      continue;
+    }
+    if (!names.some((existing) => existing.localeCompare(name, undefined, { sensitivity: "base" }) === 0)) names.push(name);
+  }
+  return { names, warnings: [...warnings] };
+}

--- a/lib/ingestion/policy.ts
+++ b/lib/ingestion/policy.ts
@@ -7,6 +7,11 @@ export function evaluateCandidate(current: Festival, candidate: FestivalCandidat
   const changes = diffFestival(current, candidate);
   const reviewReasons = new Set(candidate.warnings);
   if (candidate.festivalSlug !== current.slug) reviewReasons.add("Candidate slug does not match the current festival");
+  const catalogueYear = current.startDate ? Number(current.startDate.slice(0, 4)) : undefined;
+  const mismatchedYears = catalogueYear ? candidate.observedEditionYears.filter((year) => year !== catalogueYear) : [];
+  if (mismatchedYears.length) reviewReasons.add(`Candidate edition ${mismatchedYears.join(", ")} does not match catalogue edition ${catalogueYear}`);
+  if (candidate.lineup && candidate.lineup.length > 0 && !catalogueYear) reviewReasons.add("Catalogue edition year is unknown; lineup requires review");
+  if (candidate.lineup && candidate.lineup.length > 0 && candidate.observedEditionYears.length === 0) reviewReasons.add("Lineup edition could not be verified against the catalogue year");
   if (candidate.lineup && candidate.lineup.length === 0 && current.lineup.length > 0) reviewReasons.add("A non-empty lineup cannot be replaced by an empty lineup");
   changes.filter((change) => change.reviewRequired).forEach((change) => reviewReasons.add(change.reason || `${change.kind} requires review`));
   return { schemaVersion: INGESTION_SCHEMA_VERSION, festivalSlug: current.slug, sourceUrl: candidate.sourceUrl, fetchedAt: candidate.fetchedAt, changes, candidate, publishable: changes.length > 0 && reviewReasons.size === 0, reviewReasons: [...reviewReasons] };

--- a/lib/ingestion/types.ts
+++ b/lib/ingestion/types.ts
@@ -10,6 +10,7 @@ export type FestivalSource = {
   strategies: ParserStrategy[];
   refreshPolicy: RefreshPolicy;
   enabled: boolean;
+  editionYear: number;
   lastSuccessfulCheck?: string;
 };
 
@@ -27,6 +28,7 @@ export type FestivalCandidate = Partial<Pick<Festival, "startDate" | "endDate" |
   fetchedAt: string;
   evidence: FieldEvidence[];
   warnings: string[];
+  observedEditionYears: number[];
 };
 
 export type ChangeKind = "date_changed" | "city_changed" | "artist_added" | "artist_removed" | "headliner_added" | "headliner_removed" | "tickets_changed" | "status_changed";

--- a/tests/festival-data.test.mjs
+++ b/tests/festival-data.test.mjs
@@ -67,6 +67,7 @@ test("safe additions can publish while removals and empty replacements require r
     fetchedAt: "2026-08-28T20:00:00.000Z",
     evidence: [],
     warnings: [],
+    observedEditionYears: [2027],
   };
   const addition = evaluateCandidate(current, { ...base, lineup: [...current.lineup, "Test Artist"] });
   assert.equal(addition.publishable, true);

--- a/tests/ingestion-extract.test.mjs
+++ b/tests/ingestion-extract.test.mjs
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { extractFestivalCandidate } from "../lib/ingestion/extract.ts";
 
-const source = { festivalSlug: "example", url: "https://example.test/", strategies: ["json_ld_event", "html_fallback"], refreshPolicy: "daily", enabled: true };
+const source = { festivalSlug: "example", url: "https://example.test/", strategies: ["json_ld_event", "html_fallback"], refreshPolicy: "daily", enabled: true, editionYear: 2027 };
 
 test("combined extraction keeps JSON-LD precedence and fills missing HTML fields", () => {
   const html = `

--- a/tests/ingestion-html-fallback.test.mjs
+++ b/tests/ingestion-html-fallback.test.mjs
@@ -8,6 +8,7 @@ const source = {
   strategies: ["html_fallback"],
   refreshPolicy: "daily",
   enabled: true,
+  editionYear: 2027,
 };
 
 test("HTML fallback extracts only explicitly marked festival data", () => {

--- a/tests/ingestion-json-ld.test.mjs
+++ b/tests/ingestion-json-ld.test.mjs
@@ -8,6 +8,7 @@ const source = {
   strategies: ["json_ld_event"],
   refreshPolicy: "daily",
   enabled: true,
+  editionYear: 2027,
 };
 
 test("JSON-LD extraction normalizes dates, city, performers, and tickets", () => {

--- a/tests/ingestion-lineup-quality.test.mjs
+++ b/tests/ingestion-lineup-quality.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { extractHtmlFallbackCandidate } from "../lib/ingestion/adapters/html-fallback.ts";
+import { extractJsonLdCandidate } from "../lib/ingestion/adapters/json-ld.ts";
+import { evaluateCandidate } from "../lib/ingestion/policy.ts";
+
+const source = { festivalSlug: "fixture-fest", url: "https://fixture.test/", strategies: ["html_fallback"], refreshPolicy: "daily", enabled: true, editionYear: 2027 };
+const extracted = (markup) => extractHtmlFallbackCandidate(`<meta property="event:start_time" content="2027-07-01">${markup}`, source, "2026-08-29T12:00:00Z");
+
+test("Hurricane and Southside navigation label is not an artist", () => {
+  for (const label of ["Artists,", "Artyści"]) {
+    const candidate = extracted(`<div class="lineup-artist">${label}</div>`);
+    assert.deepEqual(candidate.lineup, []);
+    assert.ok(candidate.warnings.some((warning) => warning.includes("navigation label")));
+  }
+});
+
+test("Resurrection Fest date heading is not an artist", () => {
+  const candidate = extracted('<div class="lineup-artist">LINEUP 1 - 4 JULIO 2026</div>');
+  assert.deepEqual(candidate.lineup, []);
+  assert.ok(candidate.warnings.some((warning) => warning.includes("schedule/date/stage")));
+});
+
+test("Rock en Seine schedule and combined containers require review", () => {
+  const candidate = extracted('<div class="lineup-artist">Mer 26 Août 22:00 / Grande Scène</div><div class="lineup-artist">Band A<br>Band B</div>');
+  assert.deepEqual(candidate.lineup, []);
+  assert.ok(candidate.warnings.some((warning) => warning.includes("schedule/date/stage")));
+  assert.ok(candidate.warnings.some((warning) => warning.includes("trusted adapter")));
+});
+
+test("Eurockéennes day/date suffix is removed from a canonical artist name", () => {
+  const candidate = extracted('<div class="lineup-artist">Queens of the Stone Age — Vendredi 4 Juillet 2027</div><div class="lineup-artist">Ben Harper &amp; The Innocent Criminals dimanche 5 juillet</div>');
+  assert.deepEqual(candidate.lineup, ["Queens of the Stone Age", "Ben Harper & The Innocent Criminals"]);
+});
+
+test("Summer Breeze countdown and nested headline block are not artists", () => {
+  const candidate = extracted('<div class="lineup-artist">12 DAYS LEFT</div><div class="lineup-artist"><span>Band A</span><br><span>Band B</span></div>');
+  assert.deepEqual(candidate.lineup, []);
+  assert.equal(candidate.warnings.length, 2);
+});
+
+test("mismatched JSON-LD edition can never become publishable", () => {
+  const jsonSource = { ...source, strategies: ["json_ld_event"] };
+  const html = '<script type="application/ld+json">{"@type":"MusicEvent","startDate":"2026-08-26","performer":{"name":"Valid Band"}}</script>';
+  const candidate = extractJsonLdCandidate(html, jsonSource, "2026-08-29T12:00:00Z");
+  const current = { slug: "fixture-fest", name: "Fixture", country: "DE", city: "Berlin", startDate: "2027-07-01", endDate: "2027-07-03", officialUrl: source.url, status: "announced", headliners: [], lineup: [] };
+  const result = evaluateCandidate(current, candidate);
+  assert.equal(result.publishable, false);
+  assert.ok(result.reviewReasons.some((reason) => reason.includes("does not match catalogue edition")));
+});


### PR DESCRIPTION
Closes #21

## Summary
- validate extracted edition years against the catalogue before publication
- reject navigation, schedule, stage, countdown, ambiguous, and combined lineup containers
- normalize canonical artist names by removing day/date suffixes
- select matching-edition JSON-LD events and route unverifiable lineups to review
- add regressions for Hurricane, Southside, Mystic, Resurrection Fest, Rock en Seine, Eurockéennes, and Summer Breeze

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm run test:data` (23/23)
- `npm test` (53/53)
- `npm run build`
- live dry run: 48 processed, 2 upstream HTTP 403 fetch errors, 0 publishable, all known false positives routed to review