### PR TITLE
Persist ingestion freshness across workflow runs

### DIFF
--- a/.github/workflows/ingestion.yml
+++ b/.github/workflows/ingestion.yml
@@ -23,18 +23,33 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - name: Restore durable ingestion freshness
+        uses: actions/cache/restore@v4
+        with:
+          path: .cache/festival-ingestion/freshness.json
+          key: ${{ runner.os }}-festival-freshness-${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-festival-freshness-${{ github.ref_name }}-
       - name: Refresh due festival sources
         env:
           FESTIVAL: ${{ inputs.festival }}
         run: |
-          args=(--due --output=outputs/ingestion)
+          args=(--due --output=outputs/ingestion --state=.cache/festival-ingestion/freshness.json)
           if [[ -n "$FESTIVAL" ]]; then args+=("--slug=$FESTIVAL"); fi
           npm run ingest -- "${args[@]}"
+      - name: Save durable ingestion freshness
+        if: always() && hashFiles('.cache/festival-ingestion/freshness.json') != ''
+        uses: actions/cache/save@v4
+        with:
+          path: .cache/festival-ingestion/freshness.json
+          key: ${{ runner.os }}-festival-freshness-${{ github.ref_name }}-${{ github.run_id }}
       - name: Retain review and diagnostic artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: festival-ingestion-${{ github.run_id }}
-          path: outputs/ingestion/
+          path: |
+            outputs/ingestion/
+            .cache/festival-ingestion/freshness.json
           if-no-files-found: error
           retention-days: 30

--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ Festival ingestion runs daily and selects sources according to their adaptive
 daily, three-day, weekly, or archived cadence. Run one source with
 `npm run ingest -- --slug=wacken-open-air`; add `--due` to select only sources
 whose last successful check is older than its configured interval. Scheduled
-runs retain normalized candidates and review diagnostics for 30 days.
+runs restore and save `.cache/festival-ingestion/freshness.json` through the
+Actions cache, and expose that state alongside normalized candidates and review
+diagnostics in the 30-day workflow artifact. Only a successful HTTP fetch and
+candidate evaluation advances a source timestamp; fetch failures remain due.
 
 ## Main scripts
 

--- a/lib/ingestion/freshness-state.ts
+++ b/lib/ingestion/freshness-state.ts
@@ -1,0 +1,62 @@
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { FestivalSource } from "./types.ts";
+
+export interface FreshnessState {
+  schemaVersion: 1;
+  updatedAt: string;
+  sources: Record<string, { lastSuccessfulCheck: string }>;
+}
+
+export function emptyFreshnessState(now = new Date()): FreshnessState {
+  return { schemaVersion: 1, updatedAt: now.toISOString(), sources: {} };
+}
+
+export async function readFreshnessState(filePath: string): Promise<FreshnessState> {
+  let raw: string;
+  try {
+    raw = await readFile(filePath, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return emptyFreshnessState();
+    throw error;
+  }
+
+  const parsed = JSON.parse(raw) as Partial<FreshnessState>;
+  if (parsed.schemaVersion !== 1 || !parsed.sources || typeof parsed.sources !== "object") {
+    throw new Error(`Unsupported freshness state in ${filePath}`);
+  }
+
+  const sources: FreshnessState["sources"] = {};
+  for (const [slug, value] of Object.entries(parsed.sources)) {
+    const checkedAt = value?.lastSuccessfulCheck;
+    if (typeof checkedAt !== "string" || !Number.isFinite(Date.parse(checkedAt))) {
+      throw new Error(`Invalid lastSuccessfulCheck for ${slug} in ${filePath}`);
+    }
+    sources[slug] = { lastSuccessfulCheck: checkedAt };
+  }
+  return { schemaVersion: 1, updatedAt: parsed.updatedAt || new Date(0).toISOString(), sources };
+}
+
+export function applyFreshnessState(sources: FestivalSource[], state: FreshnessState): FestivalSource[] {
+  return sources.map((source) => ({
+    ...source,
+    lastSuccessfulCheck: state.sources[source.festivalSlug]?.lastSuccessfulCheck,
+  }));
+}
+
+export function recordCheckResult(state: FreshnessState, festivalSlug: string, checkedAt: string, successful: boolean): FreshnessState {
+  if (!successful) return state;
+  if (!Number.isFinite(Date.parse(checkedAt))) throw new Error(`Invalid successful-check timestamp: ${checkedAt}`);
+  return {
+    schemaVersion: 1,
+    updatedAt: checkedAt,
+    sources: { ...state.sources, [festivalSlug]: { lastSuccessfulCheck: checkedAt } },
+  };
+}
+
+export async function writeFreshnessState(filePath: string, state: FreshnessState): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const temporaryPath = `${filePath}.${process.pid}.tmp`;
+  await writeFile(temporaryPath, `${JSON.stringify(state, null, 2)}\n`, { mode: 0o600 });
+  await rename(temporaryPath, filePath);
+}

--- a/scripts/ingest-festivals.mjs
+++ b/scripts/ingest-festivals.mjs
@@ -6,17 +6,24 @@ import { festivalSources } from "../data/festival-sources.ts";
 import { extractFestivalCandidate } from "../lib/ingestion/extract.ts";
 import { evaluateCandidate } from "../lib/ingestion/policy.ts";
 import { dueFestivalSources } from "../lib/ingestion/schedule.ts";
+import { applyFreshnessState, readFreshnessState, recordCheckResult, writeFreshnessState } from "../lib/ingestion/freshness-state.ts";
 
 const args = new Set(process.argv.slice(2));
 const slugArg = process.argv.find((value) => value.startsWith("--slug="))?.slice(7);
 const outputArg = process.argv.find((value) => value.startsWith("--output="))?.slice(9);
+const stateArg = process.argv.find((value) => value.startsWith("--state="))?.slice(8);
 const outputDirectory = path.resolve(outputArg || "outputs/ingestion");
-const eligible = args.has("--due") ? dueFestivalSources(festivalSources) : festivalSources.filter((source) => source.enabled);
+const statePath = path.resolve(stateArg || ".cache/festival-ingestion/freshness.json");
+let freshnessState = await readFreshnessState(statePath);
+const hydratedSources = applyFreshnessState(festivalSources, freshnessState);
+const eligible = args.has("--due") ? dueFestivalSources(hydratedSources) : hydratedSources.filter((source) => source.enabled);
 const selected = eligible.filter((source) => !slugArg || source.festivalSlug === slugArg);
-if (selected.length === 0) throw new Error(slugArg ? `Unknown or disabled festival source: ${slugArg}` : "No enabled festival sources");
+if (slugArg && !hydratedSources.some((source) => source.enabled && source.festivalSlug === slugArg)) {
+  throw new Error(`Unknown or disabled festival source: ${slugArg}`);
+}
 
 await mkdir(outputDirectory, { recursive: true });
-const summary = { schemaVersion: 1, generatedAt: new Date().toISOString(), dryRun: !args.has("--publish"), processed: 0, changed: 0, publishable: 0, reviewRequired: 0, fetchErrors: 0, results: [] };
+const summary = { schemaVersion: 1, generatedAt: new Date().toISOString(), dryRun: !args.has("--publish"), freshnessStatePath: statePath, enabledSources: hydratedSources.filter(({ enabled }) => enabled).length, dueSources: selected.length, processed: 0, changed: 0, publishable: 0, reviewRequired: 0, fetchErrors: 0, results: [] };
 
 for (const source of selected) {
   const current = festivals.find(({ slug }) => slug === source.festivalSlug);
@@ -40,6 +47,8 @@ for (const source of selected) {
     if (result.publishable) summary.publishable += 1;
     if (result.reviewReasons.length) summary.reviewRequired += 1;
     summary.results.push({ festivalSlug: source.festivalSlug, status, changes: result.changes.length, reviewReasons: result.reviewReasons });
+    freshnessState = recordCheckResult(freshnessState, source.festivalSlug, fetchedAt, true);
+    await writeFreshnessState(statePath, freshnessState);
   } catch (error) {
     summary.fetchErrors += 1;
     summary.results.push({ festivalSlug: source.festivalSlug, status: "fetch_error", error: error instanceof Error ? error.message : String(error) });

--- a/tests/ingestion-schedule.test.mjs
+++ b/tests/ingestion-schedule.test.mjs
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
+import { applyFreshnessState, emptyFreshnessState, readFreshnessState, recordCheckResult, writeFreshnessState } from "../lib/ingestion/freshness-state.ts";
 import { dueFestivalSources, isSourceDue } from "../lib/ingestion/schedule.ts";
 
 const now = new Date("2026-08-28T21:00:00Z");
@@ -25,4 +29,34 @@ test("refresh intervals select only due sources", () => {
 
 test("invalid timestamps are retried", () => {
   assert.equal(isSourceDue(source("daily", "not-a-date"), now), true);
+});
+
+test("successful checks persist and hydrate after a process restart", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "festival-freshness-"));
+  const statePath = path.join(directory, "freshness.json");
+  try {
+    const persisted = recordCheckResult(emptyFreshnessState(now), "weekly", "2026-08-28T20:00:00Z", true);
+    await writeFreshnessState(statePath, persisted);
+    const restartedSources = applyFreshnessState([source("weekly")], await readFreshnessState(statePath));
+    assert.equal(restartedSources[0].lastSuccessfulCheck, "2026-08-28T20:00:00Z");
+    assert.equal(isSourceDue(restartedSources[0], now), false);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("a fetch failure leaves the previous successful-check timestamp unchanged", () => {
+  const before = recordCheckResult(emptyFreshnessState(now), "daily", "2026-08-27T21:00:00Z", true);
+  const afterFailure = recordCheckResult(before, "daily", "2026-08-28T21:00:00Z", false);
+  assert.deepEqual(afterFailure, before);
+  assert.equal(applyFreshnessState([source("daily")], afterFailure)[0].lastSuccessfulCheck, "2026-08-27T21:00:00Z");
+});
+
+test("independent daily, three-day and weekly schedules survive hydration", () => {
+  let state = emptyFreshnessState(now);
+  state = recordCheckResult(state, "daily", "2026-08-27T20:59:59Z", true);
+  state = recordCheckResult(state, "every_3_days", "2026-08-27T20:59:59Z", true);
+  state = recordCheckResult(state, "weekly", "2026-08-21T20:59:59Z", true);
+  const hydrated = applyFreshnessState([source("daily"), source("every_3_days"), source("weekly")], state);
+  assert.deepEqual(dueFestivalSources(hydrated, now).map(({ refreshPolicy }) => refreshPolicy), ["daily", "weekly"]);
 });


### PR DESCRIPTION
Closes #20

## Summary
- persist validated per-source successful-check timestamps atomically
- hydrate `--due` scheduling across independent process and workflow runs
- restore/save branch-scoped Actions cache and expose freshness in diagnostics
- preserve previous timestamps on fetch failures

## Verification
- `git diff --check`
- `npm run typecheck`
- `npm run test:data` (20/20)
- `npm test` (53/53)
- `npm run build`
- workflow YAML parse and Node syntax check
- `npm audit --audit-level=critical` (no critical vulnerabilities; four pre-existing high Prisma transitive advisories)