### PR TITLE
Fix Plesk production reconfiguration

### DIFF
--- a/scripts/deploy/install-release.sh
+++ b/scripts/deploy/install-release.sh
@@ -75,12 +75,7 @@ ln -sfn "$release" "$app_root/current"
 chown -R www-data:www-data "$release" "$shared"
 systemctl daemon-reload
 systemctl enable --now "$service"
-if command -v plesk >/dev/null 2>&1; then
-  plesk bin httpdmng --reconfigure-domain "$domain"
-else
-  apache2ctl configtest
-  systemctl reload apache2
-fi
+bash "$release/scripts/deploy/reconfigure-webserver.sh" "$domain"
 
 healthy=false
 for _ in $(seq 1 20); do

--- a/scripts/deploy/reconfigure-webserver.sh
+++ b/scripts/deploy/reconfigure-webserver.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+domain="${1:?usage: reconfigure-webserver.sh DOMAIN}"
+plesk_httpdmng="${PLESK_HTTPDMNG:-/usr/local/psa/admin/sbin/httpdmng}"
+
+if [[ -x "$plesk_httpdmng" ]]; then
+  "$plesk_httpdmng" --reconfigure-domain "$domain"
+else
+  apache2ctl configtest
+  systemctl reload apache2
+fi

--- a/tests/deploy-reconfigure.test.mjs
+++ b/tests/deploy-reconfigure.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const script = path.resolve("scripts/deploy/reconfigure-webserver.sh");
+
+async function executable(file, contents) {
+  await writeFile(file, `#!/usr/bin/env bash\nset -euo pipefail\n${contents}\n`);
+  await chmod(file, 0o755);
+}
+
+test("uses the supported Plesk httpdmng executable", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "festival-plesk-"));
+  const log = path.join(directory, "calls.log");
+  const httpdmng = path.join(directory, "httpdmng");
+  await executable(httpdmng, `printf 'httpdmng:%s\\n' "$*" >> "${log}"`);
+
+  const result = spawnSync("bash", [script, "festivals.kir-it.de"], {
+    encoding: "utf8",
+    env: { ...process.env, PLESK_HTTPDMNG: httpdmng },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(await readFile(log, "utf8"), "httpdmng:--reconfigure-domain festivals.kir-it.de\n");
+});
+
+test("validates Apache before reloading when Plesk is unavailable", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "festival-apache-"));
+  const log = path.join(directory, "calls.log");
+  await executable(path.join(directory, "apache2ctl"), `printf 'apache2ctl:%s\\n' "$*" >> "${log}"`);
+  await executable(path.join(directory, "systemctl"), `printf 'systemctl:%s\\n' "$*" >> "${log}"`);
+
+  const result = spawnSync("bash", [script, "festivals.kir-it.de"], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${directory}:${process.env.PATH}`,
+      PLESK_HTTPDMNG: path.join(directory, "missing"),
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(
+    await readFile(log, "utf8"),
+    "apache2ctl:configtest\nsystemctl:reload apache2\n",
+  );
+});


### PR DESCRIPTION
## Summary
- use the supported Plesk `httpdmng` executable directly
- retain validated Apache reload fallback
- add regression tests for both server paths

## Verification
- shell syntax checks
- data/deploy tests: 19/19
- Python tests: 53/53
- TypeScript
- production build: 216 pages
- git diff --check

Closes #90