### PR TITLE
Package deployment helper in standalone releases

### DIFF
--- a/scripts/deploy/package-release.sh
+++ b/scripts/deploy/package-release.sh
@@ -7,7 +7,7 @@ stage="$(mktemp -d)"
 trap 'rm -rf "$stage"' EXIT
 
 test -f .next/standalone/server.js
-mkdir -p "$stage/app/.next" "$stage/app/.runtime"
+mkdir -p "$stage/app/.next" "$stage/app/.runtime" "$stage/app/scripts/deploy"
 cp "$(command -v node)" "$stage/app/.runtime/node"
 chmod 0755 "$stage/app/.runtime/node"
 cp -a .next/standalone/. "$stage/app/"
@@ -15,6 +15,8 @@ cp -a .next/static "$stage/app/.next/static"
 cp -a public "$stage/app/public"
 cp package.json package-lock.json "$stage/app/"
 cp -a prisma "$stage/app/prisma"
+cp scripts/deploy/reconfigure-webserver.sh "$stage/app/scripts/deploy/"
+chmod 0755 "$stage/app/scripts/deploy/reconfigure-webserver.sh"
 printf '%s\n' "$commit" > "$stage/app/DEPLOYED_COMMIT"
 tar -C "$stage" -czf "$output" app
-tar -tzf "$output" >/dev/null
+tar -tzf "$output" | grep -Fxq 'app/scripts/deploy/reconfigure-webserver.sh'

--- a/tests/deploy-reconfigure.test.mjs
+++ b/tests/deploy-reconfigure.test.mjs
@@ -7,6 +7,15 @@ import test from "node:test";
 
 const script = path.resolve("scripts/deploy/reconfigure-webserver.sh");
 
+test("release packaging includes the helper required by the installer", async () => {
+  const packager = await readFile("scripts/deploy/package-release.sh", "utf8");
+  const installer = await readFile("scripts/deploy/install-release.sh", "utf8");
+
+  assert.match(packager, /cp scripts\/deploy\/reconfigure-webserver\.sh/);
+  assert.match(packager, /app\/scripts\/deploy\/reconfigure-webserver\.sh/);
+  assert.match(installer, /scripts\/deploy\/reconfigure-webserver\.sh/);
+});
+
 async function executable(file, contents) {
   await writeFile(file, `#!/usr/bin/env bash\nset -euo pipefail\n${contents}\n`);
   await chmod(file, 0o755);


### PR DESCRIPTION
## Summary
- package the required web-server reconfiguration helper in standalone releases
- verify its exact archive path during packaging
- add an installer/package contract regression test

## Verification
- shell syntax checks
- data/deploy tests: 20/20
- Python tests: 53/53
- TypeScript
- production build: 216 pages
- real archive contains the executable helper
- git diff --check

Closes #93