### PR TITLE
Avoid false tar failure during package validation

### DIFF
--- a/scripts/deploy/package-release.sh
+++ b/scripts/deploy/package-release.sh
@@ -19,4 +19,6 @@ cp scripts/deploy/reconfigure-webserver.sh "$stage/app/scripts/deploy/"
 chmod 0755 "$stage/app/scripts/deploy/reconfigure-webserver.sh"
 printf '%s\n' "$commit" > "$stage/app/DEPLOYED_COMMIT"
 tar -C "$stage" -czf "$output" app
-tar -tzf "$output" | grep -Fxq 'app/scripts/deploy/reconfigure-webserver.sh'
+archive_contents="$stage/archive-contents.txt"
+tar -tzf "$output" > "$archive_contents"
+grep -Fxq 'app/scripts/deploy/reconfigure-webserver.sh' "$archive_contents"


### PR DESCRIPTION
Validates the complete archive listing before exact-path lookup, avoiding SIGPIPE under pipefail.

Verified: shell syntax, data/deploy 20/20, Python 53/53, TypeScript, production build, real archive packaging.

Closes #95