### PR TITLE
Use a canonical artist in production deploy smoke

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,7 +93,7 @@ jobs:
               && curl --fail --silent --show-error --max-time 20 https://festivals.kir-it.de/ | grep --quiet 'Festival Radar' \
               && curl --fail --silent --show-error --max-time 20 https://festivals.kir-it.de/planner/ >/dev/null \
               && curl --fail --silent --show-error --max-time 20 https://festivals.kir-it.de/festivals/wacken-open-air/ >/dev/null \
-              && curl --fail --silent --show-error --max-time 20 https://festivals.kir-it.de/artists/iron-maiden/ >/dev/null; then
+              && curl --fail --silent --show-error --max-time 20 https://festivals.kir-it.de/artists/architects/ >/dev/null; then
               exit 0
             fi
             sleep 5

--- a/tests/festival-data.test.mjs
+++ b/tests/festival-data.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import { test } from "node:test";
 import { festivals } from "../data/festivals.ts";
 import { artistProfiles } from "../data/artists.ts";
@@ -32,6 +33,14 @@ test("every lineup name has one unambiguous artist profile", () => {
     assert.ok(artist.links.some(({ source }) => source === "musicbrainz"));
     assert.ok(artist.links.some(({ source }) => source === "setlist.fm"));
   }
+});
+
+test("the production deploy smoke uses an existing artist profile", async () => {
+  const workflow = await readFile(".github/workflows/deploy.yml", "utf8");
+  const match = workflow.match(/festivals\.kir-it\.de\/artists\/([a-z0-9-]+)\//);
+
+  assert.ok(match, "deploy workflow must smoke-test an artist route");
+  assert.ok(artistProfiles.some(({ slug }) => slug === match[1]), match[1]);
 });
 
 test("curated identities include provenance and stable provider IDs", () => {


### PR DESCRIPTION
Replaces a nonexistent artist smoke route with the canonical Architects profile and ties the workflow URL to the generated artist catalog in a regression test.

Verified: data/deploy tests 21/21, TypeScript, git diff check, live production route 200.

Closes #100