### PR TITLE
Restart service after switching production release

### DIFF
--- a/scripts/deploy/install-release.sh
+++ b/scripts/deploy/install-release.sh
@@ -74,7 +74,8 @@ APACHE
 ln -sfn "$release" "$app_root/current"
 chown -R www-data:www-data "$release" "$shared"
 systemctl daemon-reload
-systemctl enable --now "$service"
+systemctl enable "$service"
+systemctl restart "$service"
 bash "$release/scripts/deploy/reconfigure-webserver.sh" "$domain"
 
 healthy=false

--- a/tests/deploy-reconfigure.test.mjs
+++ b/tests/deploy-reconfigure.test.mjs
@@ -16,6 +16,14 @@ test("release packaging includes the helper required by the installer", async ()
   assert.match(installer, /scripts\/deploy\/reconfigure-webserver\.sh/);
 });
 
+test("release activation explicitly restarts an already-running service", async () => {
+  const installer = await readFile("scripts/deploy/install-release.sh", "utf8");
+
+  assert.match(installer, /systemctl enable "\$service"/);
+  assert.match(installer, /systemctl restart "\$service"/);
+  assert.doesNotMatch(installer, /systemctl enable --now "\$service"/);
+});
+
 async function executable(file, contents) {
   await writeFile(file, `#!/usr/bin/env bash\nset -euo pipefail\n${contents}\n`);
   await chmod(file, 0o755);


### PR DESCRIPTION
Explicitly restarts the service after switching the current release, so subsequent deploys serve the intended SHA before health verification. Adds a regression contract.

Verified: shell syntax, data/deploy tests 22/22, TypeScript, diff check.

Closes #102