### PR TITLE
Fix clean-checkout Prisma generation (#105)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           python-version: "3.11"
       - run: npm ci
+      - run: npm run prisma:generate
       - run: npm run typecheck
       - run: npm run test:data
       - run: python3 -m pip install -r requirements.txt

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
+    "prisma:generate": "prisma generate",
+    "postinstall": "npm run prisma:generate",
+    "pretypecheck": "npm run prisma:generate",
     "build": "next build",
+    "prebuild": "npm run prisma:generate",
     "typecheck": "tsc --noEmit",
     "fetch:logos": "node scripts/fetch-festival-logos.mjs",
     "check:sources": "node scripts/check-festival-sources.mjs",


### PR DESCRIPTION
Closes #105

## Summary
- generate Prisma Client during clean dependency installation
- regenerate before typecheck and production builds
- make Prisma generation explicit in the clean GitHub Actions quality job

## Verification
- clean `npm ci` (including postinstall Prisma generation)
- `npm run typecheck`
- `npm run test:data` (22/22)
- `python3 -m unittest discover -s tests` (53/53)
- `npm run build`

`python3 -m pip install -r requirements.txt` could not run locally because this host Python lacks pip; the Python suite itself passed and CI installs requirements on GitHub.