### PR TITLE
Add deployment SSH credential preflight (#89)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,6 +53,8 @@ jobs:
             StrictHostKeyChecking yes
           EOF
           chmod 600 ~/.ssh/config
+      - name: Preflight SSH access
+        run: bash scripts/deploy/preflight-ssh.sh production
       - name: Create protected runtime environment
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}

--- a/docs/deployment-key-rotation.md
+++ b/docs/deployment-key-rotation.md
@@ -1,0 +1,35 @@
+# Production deployment key rotation
+
+Festival Radar deployments use the GitHub `production` environment secrets
+`DEPLOY_SSH_KEY`, `DEPLOY_HOST`, `DEPLOY_PORT`, and `DEPLOY_KNOWN_HOSTS`. Keep
+the private key only in the environment secret and install only its public half
+on the production server.
+
+## Install or rotate
+
+1. Generate a dedicated Ed25519 key pair on a trusted administration host. Do
+   not reuse a personal login key and do not print the private key in logs.
+2. Add the new public key to the production deploy account's
+   `authorized_keys`. Keep the previous public key temporarily so rollback is
+   possible.
+3. From a trusted host, verify the new key non-interactively with strict host
+   checking enabled:
+
+   ```sh
+   ssh -o BatchMode=yes -o IdentitiesOnly=yes \
+     -i /secure/path/new_deploy_key deploy-host true
+   ```
+
+4. Replace `DEPLOY_SSH_KEY` in the GitHub `production` environment. Confirm
+   that `DEPLOY_HOST`, `DEPLOY_PORT`, and `DEPLOY_KNOWN_HOSTS` still describe
+   the same production endpoint.
+5. Dispatch the production workflow. Its **Preflight SSH access** step must
+   pass before packaging or upload, and the workflow must complete upload,
+   activation, and production verification.
+6. Remove the previous public key only after the successful deployment has
+   been independently verified. If verification fails, restore the previous
+   secret and leave the previous public key installed while investigating.
+
+The preflight intentionally suppresses raw SSH diagnostics so host material and
+credential details cannot be copied into Actions logs. Use a trusted
+administration host for detailed diagnosis.

--- a/scripts/deploy/preflight-ssh.sh
+++ b/scripts/deploy/preflight-ssh.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target="${1:-production}"
+
+if ! ssh \
+  -o BatchMode=yes \
+  -o ConnectTimeout=15 \
+  -o ConnectionAttempts=1 \
+  "$target" true >/dev/null 2>&1; then
+  echo "Deployment SSH preflight failed: authentication or remote command access is unavailable for '$target'. Verify the production deploy key, host, port, and known-hosts secret; then retry the workflow." >&2
+  exit 1
+fi
+
+echo "Deployment SSH preflight passed for '$target'."

--- a/tests/deploy-ssh-preflight.test.mjs
+++ b/tests/deploy-ssh-preflight.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { chmod, mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import test from "node:test";
+
+const script = path.resolve("scripts/deploy/preflight-ssh.sh");
+
+async function fakeSsh(exitCode) {
+  const directory = await mkdtemp(path.join(tmpdir(), "festival-ssh-preflight-"));
+  const log = path.join(directory, "calls.log");
+  const ssh = path.join(directory, "ssh");
+  await writeFile(
+    ssh,
+    `#!/usr/bin/env bash\nprintf '%s\\n' "$*" > "${log}"\necho 'sensitive ssh diagnostic' >&2\nexit ${exitCode}\n`,
+  );
+  await chmod(ssh, 0o755);
+  return { directory, log };
+}
+
+test("performs a non-interactive SSH authentication preflight", async () => {
+  const { directory, log } = await fakeSsh(0);
+  const result = spawnSync("bash", [script, "production"], {
+    encoding: "utf8",
+    env: { ...process.env, PATH: `${directory}:${process.env.PATH}` },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /preflight passed/);
+  assert.equal(
+    await readFile(log, "utf8"),
+    "-o BatchMode=yes -o ConnectTimeout=15 -o ConnectionAttempts=1 production true\n",
+  );
+});
+
+test("returns actionable sanitized guidance when SSH is unavailable", async () => {
+  const { directory } = await fakeSsh(255);
+  const result = spawnSync("bash", [script, "production"], {
+    encoding: "utf8",
+    env: { ...process.env, PATH: `${directory}:${process.env.PATH}` },
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Verify the production deploy key, host, port, and known-hosts secret/);
+  assert.doesNotMatch(result.stderr, /sensitive ssh diagnostic/);
+});


### PR DESCRIPTION
Closes #89

## Summary
- run a non-mutating, non-interactive SSH preflight before packaging or upload
- emit sanitized actionable guidance when authentication or command access fails
- document deploy-key installation, rotation, verification, and rollback
- cover successful and failed preflight behavior with automated tests

## Verification
- clean `npm ci`
- `npm run typecheck`
- `npm run test:data` (24 passed)
- `npm test` (53 passed)
- `npm run build`
- `bash -n scripts/deploy/preflight-ssh.sh`

The latest production deployment on current `main` already completed upload/activation with the configured key; this change moves authentication validation ahead of packaging for future runs. No merge performed.