### PR TITLE
Constrain production deployment privileges (#92)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
           Host production
             HostName $DEPLOY_HOST
             Port $DEPLOY_PORT
-            User root
+            User festival-radar-deploy
             IdentityFile ~/.ssh/deploy_key
             IdentitiesOnly yes
             StrictHostKeyChecking yes
@@ -75,10 +75,10 @@ jobs:
           } > production.env
       - name: Upload and activate release
         run: |
-          scp release.tar.gz production.env scripts/deploy/install-release.sh production:/tmp/
-          ssh production bash /tmp/install-release.sh \
-            /tmp/release.tar.gz "$GITHUB_SHA" /tmp/production.env
-          ssh production rm -f /tmp/release.tar.gz /tmp/production.env /tmp/install-release.sh
+          ssh production 'test "$(id -un)" = festival-radar-deploy && sudo -n /usr/local/libexec/festival-radar/activate-release 0000000000000000000000000000000000000000 2>&1 | grep -Fq "missing regular deployment input"'
+          scp release.tar.gz "production:/var/lib/festival-radar-deploy/incoming/$GITHUB_SHA.tar.gz"
+          scp production.env "production:/var/lib/festival-radar-deploy/incoming/$GITHUB_SHA.env"
+          ssh production sudo -n /usr/local/libexec/festival-radar/activate-release "$GITHUB_SHA"
       - name: Verify production
         run: |
           for attempt in {1..12}; do

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -1,0 +1,21 @@
+# Production deployment access
+
+Production uses the unprivileged `festival-radar-deploy` account. Its SSH key may
+write only to `/var/lib/festival-radar-deploy/incoming`; it has no interactive
+root access. The only permitted sudo command is the root-owned
+`/usr/local/libexec/festival-radar/activate-release` wrapper with a commit SHA.
+The wrapper rejects unexpected callers, paths, symlinks, owners, and commit
+formats before invoking the reviewed installer.
+
+Provision or rotate the key from a trusted root checkout:
+
+```bash
+sudo bash scripts/deploy/bootstrap-deploy-user.sh /path/to/reviewed-public-key
+```
+
+Verify with `ssh production id` and
+`ssh production sudo -n /usr/local/libexec/festival-radar/activate-release 0000000000000000000000000000000000000000`.
+The first must report the deploy user; the second must reach the wrapper and
+reject the missing deployment inputs. Roll back by restoring the previous authorized key
+and root-owned wrapper files from the server backup. Remove obsolete root key
+authorization only after a successful deployment and external health checks.

--- a/scripts/deploy/activate-release
+++ b/scripts/deploy/activate-release
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit="${1:?usage: activate-release COMMIT}"
+deploy_user="festival-radar-deploy"
+incoming="/var/lib/festival-radar-deploy/incoming"
+installer="/usr/local/libexec/festival-radar/install-release.sh"
+
+[[ "$commit" =~ ^[0-9a-f]{40}$ ]] || { echo "invalid commit" >&2; exit 2; }
+[[ "${SUDO_USER:-}" == "$deploy_user" ]] || { echo "unauthorized deploy caller" >&2; exit 3; }
+
+archive="$incoming/$commit.tar.gz"
+environment="$incoming/$commit.env"
+for file in "$archive" "$environment"; do
+  test -f "$file" && test ! -L "$file" || { echo "missing regular deployment input" >&2; exit 4; }
+  test "$(stat -c %U "$file")" = "$deploy_user" || { echo "invalid deployment input owner" >&2; exit 4; }
+done
+
+exec "$installer" "$archive" "$commit" "$environment"

--- a/scripts/deploy/bootstrap-deploy-user.sh
+++ b/scripts/deploy/bootstrap-deploy-user.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+public_key="${1:?usage: bootstrap-deploy-user.sh PUBLIC_KEY_FILE}"
+deploy_user="festival-radar-deploy"
+home="/var/lib/festival-radar-deploy"
+
+test "$(id -u)" = 0
+test -s "$public_key"
+id "$deploy_user" >/dev/null 2>&1 || useradd --system --home-dir "$home" --create-home --shell /bin/bash "$deploy_user"
+install -d -o "$deploy_user" -g "$deploy_user" -m 0700 "$home/.ssh"
+install -d -o "$deploy_user" -g "$deploy_user" -m 0700 "$home/incoming"
+install -o "$deploy_user" -g "$deploy_user" -m 0600 "$public_key" "$home/.ssh/authorized_keys"
+install -d -o root -g root -m 0755 /usr/local/libexec/festival-radar
+install -o root -g root -m 0755 scripts/deploy/install-release.sh /usr/local/libexec/festival-radar/install-release.sh
+install -o root -g root -m 0755 scripts/deploy/activate-release /usr/local/libexec/festival-radar/activate-release
+printf '%s\n' 'festival-radar-deploy ALL=(root) NOPASSWD: /usr/local/libexec/festival-radar/activate-release [0-9a-f]*' > /etc/sudoers.d/festival-radar-deploy
+chmod 0440 /etc/sudoers.d/festival-radar-deploy
+visudo -cf /etc/sudoers.d/festival-radar-deploy

--- a/tests/deploy-least-privilege.test.mjs
+++ b/tests/deploy-least-privilege.test.mjs
@@ -1,0 +1,26 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("production workflow uses the constrained deploy identity and wrapper", async () => {
+  const workflow = await readFile(".github/workflows/deploy.yml", "utf8");
+  assert.match(workflow, /User festival-radar-deploy/);
+  assert.match(workflow, /sudo -n \/usr\/local\/libexec\/festival-radar\/activate-release/);
+  assert.doesNotMatch(workflow, /User root/);
+  assert.doesNotMatch(workflow, /production:\/tmp/);
+});
+
+test("bootstrap grants only the reviewed activation wrapper", async () => {
+  const bootstrap = await readFile("scripts/deploy/bootstrap-deploy-user.sh", "utf8");
+  assert.match(bootstrap, /NOPASSWD: \/usr\/local\/libexec\/festival-radar\/activate-release/);
+  assert.doesNotMatch(bootstrap, /NOPASSWD:\s*ALL/);
+  assert.match(bootstrap, /visudo -cf/);
+});
+
+test("activation wrapper validates caller, commit, input type, and owner", async () => {
+  const wrapper = await readFile("scripts/deploy/activate-release", "utf8");
+  assert.match(wrapper, /SUDO_USER/);
+  assert.match(wrapper, /\[0-9a-f\]\{40\}/);
+  assert.match(wrapper, /test ! -L/);
+  assert.match(wrapper, /stat -c %U/);
+});


### PR DESCRIPTION
Closes #92

Introduces a dedicated unprivileged production deploy identity, root-owned constrained activation wrapper, reversible provisioning, preflight, and regression coverage. Production permissions were applied and verified; the deploy key was revoked from root authorization.

Verification: clean npm ci; typecheck; 25 data/deploy tests; 53 Python tests; 216-page build; production wrapper/identity/service/health checks. No merge performed.