### PR TITLE
Allow auditable handling of partial ingestion runs

### DIFF
--- a/.github/workflows/ingestion.yml
+++ b/.github/workflows/ingestion.yml
@@ -28,6 +28,7 @@ jobs:
         env:
           FESTIVAL: ${{ inputs.festival }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          INGESTION_MAX_FETCH_ERRORS: "10"
         run: |
           args=(--due --publish --output=outputs/ingestion)
           if [[ -n "$FESTIVAL" ]]; then args+=("--slug=$FESTIVAL"); fi

--- a/scripts/ingest-festivals.mjs
+++ b/scripts/ingest-festivals.mjs
@@ -18,6 +18,7 @@ const publicationsPath = path.resolve(process.argv.find((value) => value.startsW
 const historyPath = path.resolve(process.argv.find((value) => value.startsWith("--history="))?.slice(10) || "data/ingestion-history.jsonl");
 const fixturePath = process.argv.find((value) => value.startsWith("--fixture="))?.slice(10);
 const publish = args.has("--publish");
+const maxFetchErrorsArg = process.argv.find((value) => value.startsWith("--max-fetch-errors="))?.slice(19) ?? process.env.INGESTION_MAX_FETCH_ERRORS;
 const persistenceEnabled = Boolean(process.env.DATABASE_URL);
 const persistedStates = args.has("--due") && persistenceEnabled ? await ingestionQueries.sourceStates(db) : [];
 const lastSuccessfulChecks = new Map(persistedStates.map((state) => [state.festivalSlug, state.lastSuccessfulCheck?.toISOString()]));
@@ -25,56 +26,64 @@ const hydratedSources = festivalSources.map((source) => ({ ...source, lastSucces
 const eligible = args.has("--due") ? dueFestivalSources(hydratedSources) : hydratedSources.filter((source) => source.enabled);
 const selected = eligible.filter((source) => !slugArg || source.festivalSlug === slugArg);
 if (selected.length === 0) throw new Error(slugArg ? `Unknown or disabled festival source: ${slugArg}` : "No enabled festival sources");
+const maxFetchErrors = maxFetchErrorsArg === undefined ? Math.max(0, selected.length - 1) : Number(maxFetchErrorsArg);
+if (!Number.isInteger(maxFetchErrors) || maxFetchErrors < 0) throw new Error(`Invalid maximum fetch error count: ${maxFetchErrorsArg}`);
 
 await mkdir(outputDirectory, { recursive: true });
 const trigger = process.env.GITHUB_EVENT_NAME === "schedule" ? "SCHEDULE" : "MANUAL";
 const run = persistenceEnabled ? await createIngestionRun(db, { trigger, sourceCommit: process.env.GITHUB_SHA || "local", totalSources: selected.length }) : null;
-const summary = { schemaVersion: 1, generatedAt: new Date().toISOString(), dryRun: !publish, processed: 0, changed: 0, publishable: 0, published: 0, reviewRequired: 0, fetchErrors: 0, results: [] };
+const summary = { schemaVersion: 1, generatedAt: new Date().toISOString(), dryRun: !publish, totalSources: selected.length, attempted: 0, processed: 0, changed: 0, publishable: 0, published: 0, reviewRequired: 0, fetchErrors: 0, maxFetchErrors, status: "RUNNING", results: [] };
 let publicationStore = JSON.parse(await readFile(publicationsPath, "utf8"));
 const history = [];
 
 for (const source of selected) {
+  summary.attempted += 1;
   const current = festivals.find(({ slug }) => slug === source.festivalSlug);
   if (!current) throw new Error(`No current festival for ${source.festivalSlug}`);
   const fetchedAt = new Date().toISOString();
   const startedAt = new Date();
+  let response;
+  let html;
   try {
-    const response = fixturePath ? null : await fetch(source.url, {
+    response = fixturePath ? null : await fetch(source.url, {
       redirect: "follow",
       signal: AbortSignal.timeout(20_000),
       headers: { "user-agent": "FestivalRadarBot/1.0 (+https://festivals.kir-it.de/)" },
     });
     if (response && !response.ok) throw new Error(`HTTP ${response.status}`);
-    const html = fixturePath ? await readFile(path.resolve(fixturePath), "utf8") : await response.text();
-    const candidate = extractFestivalCandidate(html, source, fetchedAt);
-    const result = evaluateCandidate(current, candidate);
-    const status = result.reviewReasons.length ? "review" : result.publishable ? "publishable" : "unchanged";
-    const artifact = { status, source: { ...source, httpStatus: response?.status ?? null, finalUrl: response?.url ?? source.url }, result };
-    if (run) await persistAttempt(db, { runId: run.id, festivalSlug: source.festivalSlug, requestedUrl: source.url, finalUrl: response?.url ?? source.url, httpStatus: response?.status ?? null, durationMs: Date.now() - startedAt.getTime(), startedAt, endedAt: new Date(), result });
-    await writeFile(path.join(outputDirectory, `${source.festivalSlug}.json`), `${JSON.stringify(artifact, null, 2)}\n`);
-    summary.processed += 1;
-    if (result.changes.length) summary.changed += 1;
-    if (result.publishable) summary.publishable += 1;
-    if (result.reviewReasons.length) summary.reviewRequired += 1;
-    let outcome = result.changes.length ? (result.reviewReasons.length ? "review_required" : "dry_run") : "unchanged";
-    if (publish && result.publishable && !result.reviewReasons.length) {
-      const nextStore = applyPublication(publicationStore, current, result);
-      if (JSON.stringify(nextStore) !== JSON.stringify(publicationStore)) { publicationStore = nextStore; summary.published += 1; outcome = "published"; }
-      else outcome = "unchanged";
-    }
-    history.push(historyRecord(result, outcome));
-    summary.results.push({ festivalSlug: source.festivalSlug, status, outcome, changes: result.changes.length, reviewReasons: result.reviewReasons });
+    html = fixturePath ? await readFile(path.resolve(fixturePath), "utf8") : await response.text();
   } catch (error) {
     if (run) await persistAttempt(db, { runId: run.id, festivalSlug: source.festivalSlug, requestedUrl: source.url, durationMs: Date.now() - startedAt.getTime(), startedAt, endedAt: new Date(), error: error instanceof Error ? error.message : String(error) });
     summary.fetchErrors += 1;
     summary.results.push({ festivalSlug: source.festivalSlug, status: "fetch_error", error: error instanceof Error ? error.message : String(error) });
+    continue;
   }
+
+  const candidate = extractFestivalCandidate(html, source, fetchedAt);
+  const result = evaluateCandidate(current, candidate);
+  const status = result.reviewReasons.length ? "review" : result.publishable ? "publishable" : "unchanged";
+  const artifact = { status, source: { ...source, httpStatus: response?.status ?? null, finalUrl: response?.url ?? source.url }, result };
+  if (run) await persistAttempt(db, { runId: run.id, festivalSlug: source.festivalSlug, requestedUrl: source.url, finalUrl: response?.url ?? source.url, httpStatus: response?.status ?? null, durationMs: Date.now() - startedAt.getTime(), startedAt, endedAt: new Date(), result });
+  await writeFile(path.join(outputDirectory, `${source.festivalSlug}.json`), `${JSON.stringify(artifact, null, 2)}\n`);
+  summary.processed += 1;
+  if (result.changes.length) summary.changed += 1;
+  if (result.publishable) summary.publishable += 1;
+  if (result.reviewReasons.length) summary.reviewRequired += 1;
+  let outcome = result.changes.length ? (result.reviewReasons.length ? "review_required" : "dry_run") : "unchanged";
+  if (publish && result.publishable && !result.reviewReasons.length) {
+    const nextStore = applyPublication(publicationStore, current, result);
+    if (JSON.stringify(nextStore) !== JSON.stringify(publicationStore)) { publicationStore = nextStore; summary.published += 1; outcome = "published"; }
+    else outcome = "unchanged";
+  }
+  history.push(historyRecord(result, outcome));
+  summary.results.push({ festivalSlug: source.festivalSlug, status, outcome, changes: result.changes.length, reviewReasons: result.reviewReasons });
 }
 
 if (run) await finishIngestionRun(db, run.id);
+summary.status = summary.fetchErrors === 0 ? "COMPLETED" : summary.fetchErrors <= maxFetchErrors ? "PARTIAL" : "FAILED";
 if (publish) await writeFile(publicationsPath, `${JSON.stringify(publicationStore, null, 2)}\n`);
 if (history.length) await appendFile(historyPath, `${history.map((record) => JSON.stringify(record)).join("\n")}\n`);
 await writeFile(path.join(outputDirectory, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
 console.log(JSON.stringify(summary));
-if (summary.fetchErrors) process.exitCode = 2;
+if (summary.status === "FAILED") process.exitCode = 2;
 if (persistenceEnabled) await db.$disconnect();

--- a/tests/ingestion-publication.test.mjs
+++ b/tests/ingestion-publication.test.mjs
@@ -37,3 +37,49 @@ test("review-required removal is never published", async () => {
   assert.equal(run(dir, "wacken-open-air", true).published, 0);
   assert.deepEqual(JSON.parse(await readFile(path.join(dir, "publications.json"), "utf8")).festivals, {});
 });
+
+test("policy-accepted source failure is reported as PARTIAL without failing downstream workflow", async () => {
+  const dir = await setup(safe);
+  const output = path.join(dir, "partial-output");
+  const result = spawnSync(process.execPath, [
+    "scripts/ingest-festivals.mjs",
+    "--slug=rock-am-ring",
+    `--fixture=${path.join(dir, "missing-fixture.html")}`,
+    `--publications=${path.join(dir, "publications.json")}`,
+    `--history=${path.join(dir, "history.jsonl")}`,
+    `--output=${output}`,
+    "--max-fetch-errors=1",
+  ], { encoding: "utf8" });
+  assert.equal(result.status, 0, result.stderr);
+  const summary = JSON.parse(result.stdout);
+  assert.equal(summary.status, "PARTIAL");
+  assert.equal(summary.totalSources, 1);
+  assert.equal(summary.attempted, 1);
+  assert.equal(summary.processed, 0);
+  assert.equal(summary.fetchErrors, 1);
+  assert.equal(JSON.parse(await readFile(path.join(output, "summary.json"), "utf8")).status, "PARTIAL");
+});
+
+test("source failures above the explicit policy threshold remain fatal", async () => {
+  const dir = await setup(safe);
+  const result = spawnSync(process.execPath, [
+    "scripts/ingest-festivals.mjs",
+    "--slug=rock-am-ring",
+    `--fixture=${path.join(dir, "missing-fixture.html")}`,
+    `--publications=${path.join(dir, "publications.json")}`,
+    `--history=${path.join(dir, "history.jsonl")}`,
+    `--output=${path.join(dir, "failed-output")}`,
+    "--max-fetch-errors=0",
+  ], { encoding: "utf8" });
+  assert.equal(result.status, 2, result.stderr);
+  const summary = JSON.parse(result.stdout);
+  assert.equal(summary.status, "FAILED");
+  assert.equal(summary.fetchErrors, 1);
+});
+
+test("workflow keeps auditable publication and artifact handling after accepted partial runs", async () => {
+  const workflow = await readFile(".github/workflows/ingestion.yml", "utf8");
+  assert.match(workflow, /INGESTION_MAX_FETCH_ERRORS: "10"/);
+  assert.match(workflow, /name: Open auditable publication pull request/);
+  assert.match(workflow, /name: Retain review and diagnostic artifacts[\s\S]*if: always\(\)/);
+});


### PR DESCRIPTION
Closes #111

Treat expected source fetch failures as a persisted PARTIAL result within an explicit policy threshold, while retaining fatal behavior for threshold breaches and system-level persistence/integrity failures. Adds regression coverage for accepted partial runs, fatal thresholds, counters, and workflow continuation.