### PR TITLE
fix: provision production scheduler authentication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,10 +60,11 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
           APP_URL: ${{ secrets.APP_URL }}
+          INTERNAL_API_SECRET: ${{ secrets.INTERNAL_API_SECRET }}
           SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
           SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
         run: |
-          for name in DATABASE_URL AUTH_SECRET APP_URL SPOTIFY_CLIENT_ID SPOTIFY_CLIENT_SECRET; do
+          for name in DATABASE_URL AUTH_SECRET APP_URL INTERNAL_API_SECRET SPOTIFY_CLIENT_ID SPOTIFY_CLIENT_SECRET; do
             test -n "${!name}" || { echo "Missing required production secret: $name" >&2; exit 1; }
           done
           umask 077
@@ -71,6 +72,7 @@ jobs:
             printf 'DATABASE_URL=%q\n' "$DATABASE_URL"
             printf 'AUTH_SECRET=%q\n' "$AUTH_SECRET"
             printf 'APP_URL=%q\n' "$APP_URL"
+            printf 'INTERNAL_API_SECRET=%q\n' "$INTERNAL_API_SECRET"
             printf 'SPOTIFY_CLIENT_ID=%q\n' "$SPOTIFY_CLIENT_ID"
             printf 'SPOTIFY_CLIENT_SECRET=%q\n' "$SPOTIFY_CLIENT_SECRET"
             printf 'DEPLOYED_COMMIT=%q\n' "$GITHUB_SHA"

--- a/.github/workflows/ingestion.yml
+++ b/.github/workflows/ingestion.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
   refresh:
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 5
     steps:
       - name: Dispatch due deliveries

--- a/tests/internal-api-workflows.test.mjs
+++ b/tests/internal-api-workflows.test.mjs
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+for (const workflowName of ["notifications", "ingestion"]) {
+  test(`${workflowName} uses production-scoped internal API credentials`, async () => {
+    const workflow = await readFile(`.github/workflows/${workflowName}.yml`, "utf8");
+    assert.match(workflow, /jobs:[\s\S]*?environment: production/);
+    assert.match(workflow, /APP_URL: \$\{\{ secrets\.APP_URL \}\}/);
+    assert.match(workflow, /INTERNAL_API_SECRET: \$\{\{ secrets\.INTERNAL_API_SECRET \}\}/);
+    assert.doesNotMatch(workflow, /INTERNAL_API_SECRET: \$\{\{ vars\./);
+  });
+}
+
+test("deployment requires and installs the internal API secret", async () => {
+  const workflow = await readFile(".github/workflows/deploy.yml", "utf8");
+  assert.match(workflow, /INTERNAL_API_SECRET: \$\{\{ secrets\.INTERNAL_API_SECRET \}\}/);
+  assert.match(workflow, /for name in DATABASE_URL AUTH_SECRET APP_URL INTERNAL_API_SECRET/);
+  assert.match(workflow, /printf 'INTERNAL_API_SECRET=%q\\n' "\$INTERNAL_API_SECRET"/);
+});
+
+for (const routeName of ["events", "dispatch"]) {
+  test(`${routeName} internal API route fails closed for unauthorized requests`, async () => {
+    const route = await readFile(`app/api/notifications/${routeName}/route.ts`, "utf8");
+    assert.match(route, /!process\.env\.INTERNAL_API_SECRET/);
+    assert.match(route, /request\.headers\.get\("authorization"\) !== `Bearer \$\{process\.env\.INTERNAL_API_SECRET\}`/);
+    assert.match(route, /return error\("Unauthorized\.", 401\)/);
+  });
+}


### PR DESCRIPTION
Closes #114

Scopes notification and ingestion jobs to the protected production environment, propagates the internal API credential into the protected runtime environment during deployment, and adds regression coverage for workflow scope plus fail-closed route authentication.

Local verification: clean npm install, typecheck, 57 data tests + 4 selection-playlist tests, 57 Python tests, 220-page production build.