### PR TITLE
fix: use canonical notification dispatch endpoint

### DIFF
--- a/.github/workflows/ingestion.yml
+++ b/.github/workflows/ingestion.yml
@@ -31,7 +31,6 @@ jobs:
           APP_URL: ${{ secrets.APP_URL }}
           INTERNAL_API_SECRET: ${{ secrets.INTERNAL_API_SECRET }}
           NOTIFICATION_DELIVERY_REQUIRED: "true"
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
           INGESTION_MAX_FETCH_ERRORS: "10"
         run: |
           args=(--due --publish --output=outputs/ingestion)

--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -28,5 +28,5 @@ jobs:
             -H "authorization: Bearer $INTERNAL_API_SECRET" \
             -H "content-type: application/json" \
             --data '{"limit":500}' \
-            "$APP_URL/api/notifications/dispatch")"
+            "${APP_URL%/}/api/notifications/dispatch/")"
           node -e 'const result=JSON.parse(process.argv[1]); const statuses=result.results.reduce((counts,item)=>({...counts,[item.status]:(counts[item.status]||0)+1}),{}); console.log(JSON.stringify({processed:result.processed,statuses}))' "$response"

--- a/scripts/ingest-festivals.mjs
+++ b/scripts/ingest-festivals.mjs
@@ -26,7 +26,7 @@ const lastSuccessfulChecks = new Map(persistedStates.map((state) => [state.festi
 const hydratedSources = festivalSources.map((source) => ({ ...source, lastSuccessfulCheck: lastSuccessfulChecks.get(source.festivalSlug) ?? source.lastSuccessfulCheck }));
 const eligible = args.has("--due") ? dueFestivalSources(hydratedSources) : hydratedSources.filter((source) => source.enabled);
 const selected = eligible.filter((source) => !slugArg || source.festivalSlug === slugArg);
-const notificationEndpoint = process.env.NOTIFICATION_EVENTS_URL || (process.env.APP_URL ? new URL("/api/notifications/events", process.env.APP_URL).toString() : undefined);
+const notificationEndpoint = process.env.NOTIFICATION_EVENTS_URL || (process.env.APP_URL ? new URL("/api/notifications/events/", process.env.APP_URL).toString() : undefined);
 const notificationDeliveryEnabled = Boolean(notificationEndpoint || process.env.INTERNAL_API_SECRET || process.env.NOTIFICATION_DELIVERY_REQUIRED === "true");
 if (publish && notificationDeliveryEnabled && (!notificationEndpoint || !process.env.INTERNAL_API_SECRET)) throw new Error("Published ingestion requires APP_URL (or NOTIFICATION_EVENTS_URL) and INTERNAL_API_SECRET");
 if (selected.length === 0) throw new Error(slugArg ? `Unknown or disabled festival source: ${slugArg}` : "No enabled festival sources");

--- a/tests/internal-api-workflows.test.mjs
+++ b/tests/internal-api-workflows.test.mjs
@@ -12,6 +12,19 @@ for (const workflowName of ["notifications", "ingestion"]) {
   });
 }
 
+test("notification scheduler posts to the canonical non-redirecting endpoint", async () => {
+  const workflow = await readFile(".github/workflows/notifications.yml", "utf8");
+  assert.match(workflow, /"\$\{APP_URL%\/\}\/api\/notifications\/dispatch\/"/);
+  assert.doesNotMatch(workflow, /"\$APP_URL\/api\/notifications\/dispatch"/);
+});
+
+test("ingestion keeps database access inside production and uses the canonical internal endpoint", async () => {
+  const workflow = await readFile(".github/workflows/ingestion.yml", "utf8");
+  const script = await readFile("scripts/ingest-festivals.mjs", "utf8");
+  assert.doesNotMatch(workflow, /DATABASE_URL: \$\{\{ secrets\.DATABASE_URL \}\}/);
+  assert.match(script, /new URL\("\/api\/notifications\/events\/", process\.env\.APP_URL\)/);
+});
+
 test("deployment requires and installs the internal API secret", async () => {
   const workflow = await readFile(".github/workflows/deploy.yml", "utf8");
   assert.match(workflow, /INTERNAL_API_SECRET: \$\{\{ secrets\.INTERNAL_API_SECRET \}\}/);


### PR DESCRIPTION
Follow-up for #114 after real scheduler run 33332441096 exposed a 308 redirect body at the non-trailing-slash endpoint. Uses the canonical route and adds a regression test.

Verification: internal API workflow tests pass; typecheck passes.