### PR TITLE
fix: retain production ingestion evidence artifact

### DIFF
--- a/.github/workflows/ingestion.yml
+++ b/.github/workflows/ingestion.yml
@@ -32,6 +32,7 @@ jobs:
           INTERNAL_API_SECRET: ${{ secrets.INTERNAL_API_SECRET }}
         run: |
           test -n "$APP_URL" && test -n "$INTERNAL_API_SECRET"
+          mkdir -p outputs
           jq -n --arg festival "$FESTIVAL" '{festival: (if $festival == "" then null else $festival end)}' > request.json
           curl --fail-with-body --silent --show-error --max-time 1200 \
             -H "authorization: Bearer $INTERNAL_API_SECRET" \

--- a/tests/internal-api-workflows.test.mjs
+++ b/tests/internal-api-workflows.test.mjs
@@ -22,6 +22,7 @@ test("ingestion keeps database access inside production and uses the canonical i
   const workflow = await readFile(".github/workflows/ingestion.yml", "utf8");
   assert.doesNotMatch(workflow, /DATABASE_URL: \$\{\{ secrets\.DATABASE_URL \}\}/);
   assert.match(workflow, /"\$\{APP_URL%\/\}\/api\/ingestion\/run\/"/);
+  assert.match(workflow, /mkdir -p outputs/);
   assert.match(workflow, /jq -e '\.runId and \(\.summary\.attempted > 0\)[\s\S]*\.readBack\.attempts == \.summary\.attempted/);
 });
 


### PR DESCRIPTION
Follow-up for #118.

The first production run proved the critical database contract (50 attempts, 48 candidates, 55 evidence records, 108 diffs, persisted failure and lastSuccessfulCheck), but the hosted job failed to retain its sanitized response because outputs/ did not exist. Create it before tee and keep regression coverage.