### PR TITLE
fix: complete production ingestion persistence acceptance

### DIFF
--- a/.github/workflows/ingestion.yml
+++ b/.github/workflows/ingestion.yml
@@ -28,18 +28,19 @@ jobs:
       - name: Run durable ingestion inside production
         env:
           FESTIVAL: ${{ inputs.festival }}
+          FORCE: ${{ github.event_name == 'workflow_dispatch' }}
           APP_URL: ${{ secrets.APP_URL }}
           INTERNAL_API_SECRET: ${{ secrets.INTERNAL_API_SECRET }}
         run: |
           test -n "$APP_URL" && test -n "$INTERNAL_API_SECRET"
           mkdir -p outputs
-          jq -n --arg festival "$FESTIVAL" '{festival: (if $festival == "" then null else $festival end)}' > request.json
+          jq -n --arg festival "$FESTIVAL" --argjson force "$FORCE" '{festival: (if $festival == "" then null else $festival end), force: $force}' > request.json
           curl --fail-with-body --silent --show-error --max-time 1200 \
             -H "authorization: Bearer $INTERNAL_API_SECRET" \
             -H "content-type: application/json" \
             --data-binary @request.json \
             "${APP_URL%/}/api/ingestion/run/" | tee outputs/ingestion-response.json
-          jq -e '.runId and (.summary.attempted > 0) and (.readBack.attempts == .summary.attempted) and (.readBack.candidates > 0) and (.readBack.evidence > 0) and .readBack.lastSuccessfulCheck and (.summary.status == "COMPLETED" or .summary.status == "PARTIAL")' outputs/ingestion-response.json
+          jq -e '.runId and (.summary.attempted > 0) and (.readBack.attempts == .summary.attempted) and (.summary.status == "COMPLETED" or .summary.status == "PARTIAL") and (if env.FORCE == "true" then (.summary.totalSources == 50 and .summary.attempted == 50 and .readBack.candidates > 0 and .readBack.evidence > 0 and .readBack.diffs > 0 and .readBack.hasPersistedFailure and .readBack.lastSuccessfulCheck) else true end)' outputs/ingestion-response.json
       - name: Retain review and diagnostic artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/app/api/ingestion/run/route.ts
+++ b/app/api/ingestion/run/route.ts
@@ -12,7 +12,10 @@ export const dynamic = "force-dynamic";
 export const maxDuration = 1_200;
 
 const execute = promisify(execFile);
-const input = z.object({ festival: z.string().trim().min(1).max(120).nullable().optional() });
+const input = z.object({
+  festival: z.string().trim().min(1).max(120).nullable().optional(),
+  force: z.boolean().optional().default(false),
+});
 
 export async function POST(request: Request) {
   if (!process.env.INTERNAL_API_SECRET || request.headers.get("authorization") !== `Bearer ${process.env.INTERNAL_API_SECRET}`) return error("Unauthorized.", 401);
@@ -25,13 +28,18 @@ export async function POST(request: Request) {
   await mkdir(outputDirectory, { recursive: true });
   const args = ["--experimental-strip-types", "scripts/ingest-festivals.mjs", "--due", "--publish", `--output=${outputDirectory}`, "--max-fetch-errors=10"];
   if (parsed.data.festival) args.push(`--slug=${parsed.data.festival}`);
+  if (parsed.data.force) args.push("--force");
   try {
-    await execute(process.execPath, args, {
-      cwd: process.cwd(),
-      env: { ...process.env, GITHUB_EVENT_NAME: "workflow_dispatch", GITHUB_SHA: process.env.DEPLOYED_COMMIT ?? "production" },
-      timeout: 1_100_000,
-      maxBuffer: 10 * 1024 * 1024,
-    });
+    try {
+      await execute(process.execPath, args, {
+        cwd: process.cwd(),
+        env: { ...process.env, GITHUB_EVENT_NAME: "workflow_dispatch", GITHUB_SHA: process.env.DEPLOYED_COMMIT ?? "production" },
+        timeout: 1_100_000,
+        maxBuffer: 10 * 1024 * 1024,
+      });
+    } catch (cause) {
+      if (!(cause && typeof cause === "object" && "code" in cause && cause.code === 2)) throw cause;
+    }
     const summary = JSON.parse(await readFile(path.join(outputDirectory, "summary.json"), "utf8"));
     if (!summary.ingestionRunId) throw new Error("Runner did not create a durable ingestion run");
     const persisted = await db.ingestionRun.findUnique({

--- a/tests/internal-api-workflows.test.mjs
+++ b/tests/internal-api-workflows.test.mjs
@@ -23,7 +23,9 @@ test("ingestion keeps database access inside production and uses the canonical i
   assert.doesNotMatch(workflow, /DATABASE_URL: \$\{\{ secrets\.DATABASE_URL \}\}/);
   assert.match(workflow, /"\$\{APP_URL%\/\}\/api\/ingestion\/run\/"/);
   assert.match(workflow, /mkdir -p outputs/);
+  assert.match(workflow, /--argjson force "\$FORCE"/);
   assert.match(workflow, /jq -e '\.runId and \(\.summary\.attempted > 0\)[\s\S]*\.readBack\.attempts == \.summary\.attempted/);
+  assert.match(workflow, /\.summary\.totalSources == 50[\s\S]*\.readBack\.diffs > 0[\s\S]*\.readBack\.hasPersistedFailure[\s\S]*\.readBack\.lastSuccessfulCheck/);
 });
 
 test("deployment requires and installs the internal API secret", async () => {
@@ -49,6 +51,8 @@ test("production ingestion route fails closed and invokes the persistent runner"
   assert.match(route, /Durable ingestion is unavailable\./);
   assert.match(route, /scripts\/ingest-festivals\.mjs/);
   assert.match(route, /--max-fetch-errors=10/);
+  assert.match(route, /if \(parsed\.data\.force\) args\.push\("--force"\)/);
+  assert.match(route, /cause\.code === 2/);
   assert.match(route, /persisted\.attempts\.length !== summary\.attempted/);
   assert.match(route, /lastSuccessfulCheck/);
 });


### PR DESCRIPTION
Follow-up remediation for #118 after production runs exposed accepted PARTIAL exit handling.

- treats runner exit 2 as an accepted persisted PARTIAL result and still performs PostgreSQL read-back
- forces all 50 sources on manual acceptance runs
- keeps scheduled runs adaptive
- requires 50 attempts plus candidate/evidence/diff lineage, a persisted failed attempt, and lastSuccessfulCheck during forced production acceptance

Closes #118