### PR TITLE
fix: force all sources during ingestion acceptance

### DIFF
--- a/scripts/ingest-festivals.mjs
+++ b/scripts/ingest-festivals.mjs
@@ -19,12 +19,14 @@ const publicationsPath = path.resolve(process.argv.find((value) => value.startsW
 const historyPath = path.resolve(process.argv.find((value) => value.startsWith("--history="))?.slice(10) || "data/ingestion-history.jsonl");
 const fixturePath = process.argv.find((value) => value.startsWith("--fixture="))?.slice(10);
 const publish = args.has("--publish");
+const force = args.has("--force");
 const maxFetchErrorsArg = process.argv.find((value) => value.startsWith("--max-fetch-errors="))?.slice(19) ?? process.env.INGESTION_MAX_FETCH_ERRORS;
 const persistenceEnabled = Boolean(process.env.DATABASE_URL);
-const persistedStates = args.has("--due") && persistenceEnabled ? await ingestionQueries.sourceStates(db) : [];
+const dueOnly = args.has("--due") && !force;
+const persistedStates = dueOnly && persistenceEnabled ? await ingestionQueries.sourceStates(db) : [];
 const lastSuccessfulChecks = new Map(persistedStates.map((state) => [state.festivalSlug, state.lastSuccessfulCheck?.toISOString()]));
 const hydratedSources = festivalSources.map((source) => ({ ...source, lastSuccessfulCheck: lastSuccessfulChecks.get(source.festivalSlug) ?? source.lastSuccessfulCheck }));
-const eligible = args.has("--due") ? dueFestivalSources(hydratedSources) : hydratedSources.filter((source) => source.enabled);
+const eligible = dueOnly ? dueFestivalSources(hydratedSources) : hydratedSources.filter((source) => source.enabled);
 const selected = eligible.filter((source) => !slugArg || source.festivalSlug === slugArg);
 const notificationEndpoint = process.env.NOTIFICATION_EVENTS_URL || (process.env.APP_URL ? new URL("/api/notifications/events/", process.env.APP_URL).toString() : undefined);
 const notificationDeliveryEnabled = Boolean(notificationEndpoint || process.env.INTERNAL_API_SECRET || process.env.NOTIFICATION_DELIVERY_REQUIRED === "true");

--- a/tests/internal-api-workflows.test.mjs
+++ b/tests/internal-api-workflows.test.mjs
@@ -28,6 +28,13 @@ test("ingestion keeps database access inside production and uses the canonical i
   assert.match(workflow, /\.summary\.totalSources == 50[\s\S]*\.readBack\.diffs > 0[\s\S]*\.readBack\.hasPersistedFailure[\s\S]*\.readBack\.lastSuccessfulCheck/);
 });
 
+test("forced ingestion bypasses adaptive due filtering for full acceptance runs", async () => {
+  const runner = await readFile("scripts/ingest-festivals.mjs", "utf8");
+  assert.match(runner, /const force = args\.has\("--force"\)/);
+  assert.match(runner, /const dueOnly = args\.has\("--due"\) && !force/);
+  assert.match(runner, /const eligible = dueOnly \? dueFestivalSources/);
+});
+
 test("deployment requires and installs the internal API secret", async () => {
   const workflow = await readFile(".github/workflows/deploy.yml", "utf8");
   assert.match(workflow, /INTERNAL_API_SECRET: \$\{\{ secrets\.INTERNAL_API_SECRET \}\}/);


### PR DESCRIPTION
Follow-up production remediation for #118. Production run 33381040161 proved that the API passed `--force` but the runner still applied adaptive `--due` filtering and processed only 2/50 sources. This change makes `--force` bypass due filtering while scheduled runs remain adaptive. Acceptance: CI, deploy, then a forced production run must persist and read back exactly 50 attempts with candidate/evidence/diff lineage, a persisted failure, and `lastSuccessfulCheck`.

Refs #118