### PR TITLE
Move notification scheduling into production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,6 +80,7 @@ jobs:
             printf 'ANALYTICS_RETENTION_DAYS=%q\n' "$ANALYTICS_RETENTION_DAYS"
             printf 'SPOTIFY_CLIENT_ID=%q\n' "$SPOTIFY_CLIENT_ID"
             printf 'SPOTIFY_CLIENT_SECRET=%q\n' "$SPOTIFY_CLIENT_SECRET"
+            printf 'NOTIFICATION_SCHEDULER_STATE_FILE=%q\n' '/opt/festival-radar/shared/notification-scheduler-state.json'
             printf 'DEPLOYED_COMMIT=%q\n' "$GITHUB_SHA"
           } > production.env
       - name: Upload and activate release

--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -1,8 +1,6 @@
 name: Dispatch notifications
 
 on:
-  schedule:
-    - cron: "*/10 * * * *"
   workflow_dispatch:
 
 concurrency:

--- a/app/api/health/notification-scheduler/route.ts
+++ b/app/api/health/notification-scheduler/route.ts
@@ -1,0 +1,16 @@
+import { readFile } from "node:fs/promises";
+
+const maximumAgeMs = 20 * 60 * 1000;
+
+export async function GET() {
+  const path = process.env.NOTIFICATION_SCHEDULER_STATE_FILE;
+  if (!path) return Response.json({ status: "unconfigured" }, { status: 503 });
+  try {
+    const state = JSON.parse(await readFile(path, "utf8")) as { finishedAt?: string; ok?: boolean; processed?: number; statuses?: Record<string, number> };
+    const ageMs = state.finishedAt ? Date.now() - Date.parse(state.finishedAt) : Number.POSITIVE_INFINITY;
+    const healthy = state.ok === true && Number.isFinite(ageMs) && ageMs <= maximumAgeMs;
+    return Response.json({ status: healthy ? "ok" : "stale", ...state, ageSeconds: Number.isFinite(ageMs) ? Math.max(0, Math.round(ageMs / 1000)) : null }, { status: healthy ? 200 : 503 });
+  } catch {
+    return Response.json({ status: "missing" }, { status: 503 });
+  }
+}

--- a/docs/production-deployment.md
+++ b/docs/production-deployment.md
@@ -19,3 +19,21 @@ The first must report the deploy user; the second must reach the wrapper and
 reject the missing deployment inputs. Roll back by restoring the previous authorized key
 and root-owned wrapper files from the server backup. Remove obsolete root key
 authorization only after a successful deployment and external health checks.
+
+## Notification scheduler
+
+Deployments install `festival-radar-notifications.timer` on the production host.
+It invokes the authenticated loopback dispatcher every ten minutes, uses `flock`
+to prevent overlap, and records only timestamps and aggregate statuses in the
+shared scheduler-state file. GitHub Actions retains a manual diagnostic dispatch
+but is not the production scheduler.
+
+Verify ownership and cadence with `systemctl status
+festival-radar-notifications.timer`, `systemctl list-timers
+festival-radar-notifications.timer`, and
+`journalctl -u festival-radar-notifications.service`. The public
+`/api/health/notification-scheduler/` endpoint returns 503 when the last
+successful completion is missing, failed, or older than twenty minutes. A failed
+unit is retried on the next timer interval; after correcting the underlying
+secret, provider, or application failure, run `systemctl start
+festival-radar-notifications.service` and verify the health endpoint returns 200.

--- a/scripts/deploy/install-release.sh
+++ b/scripts/deploy/install-release.sh
@@ -66,6 +66,41 @@ ReadWritePaths=$app_root
 WantedBy=multi-user.target
 UNIT
 
+cat > "/etc/systemd/system/$service-notifications.service" <<UNIT
+[Unit]
+Description=Festival Radar notification dispatcher
+After=$service.service
+Requires=$service.service
+
+[Service]
+Type=oneshot
+User=www-data
+Group=www-data
+EnvironmentFile=$shared/production.env
+Environment=NODE_BINARY=$release/.runtime/node
+ExecStart=$release/scripts/notifications/dispatch-production.sh
+RuntimeDirectory=festival-radar-notifications
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ReadWritePaths=$shared /run/festival-radar-notifications
+UNIT
+
+cat > "/etc/systemd/system/$service-notifications.timer" <<UNIT
+[Unit]
+Description=Dispatch Festival Radar notifications every ten minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitInactiveSec=10min
+AccuracySec=15s
+Persistent=true
+Unit=$service-notifications.service
+
+[Install]
+WantedBy=timers.target
+UNIT
+
 vhost="/var/www/vhosts/system/$domain/conf/vhost.conf"
 install -d -m 0755 "$(dirname "$vhost")"
 cat > "$vhost" <<APACHE
@@ -85,6 +120,7 @@ chown -R www-data:www-data "$release" "$shared"
 systemctl daemon-reload
 systemctl enable "$service"
 systemctl restart "$service"
+systemctl enable --now "$service-notifications.timer"
 bash "$release/scripts/deploy/reconfigure-webserver.sh" "$domain"
 
 healthy=false

--- a/scripts/deploy/package-release.sh
+++ b/scripts/deploy/package-release.sh
@@ -7,7 +7,7 @@ stage="$(mktemp -d)"
 trap 'rm -rf "$stage"' EXIT
 
 test -f .next/standalone/server.js
-mkdir -p "$stage/app/.next" "$stage/app/.runtime" "$stage/app/scripts/deploy"
+mkdir -p "$stage/app/.next" "$stage/app/.runtime" "$stage/app/scripts/deploy" "$stage/app/scripts/notifications"
 cp "$(command -v node)" "$stage/app/.runtime/node"
 chmod 0755 "$stage/app/.runtime/node"
 cp -a .next/standalone/. "$stage/app/"
@@ -18,9 +18,12 @@ cp -a prisma "$stage/app/prisma"
 cp -a data lib "$stage/app/"
 cp scripts/ingest-festivals.mjs "$stage/app/scripts/"
 cp scripts/deploy/reconfigure-webserver.sh "$stage/app/scripts/deploy/"
+cp scripts/notifications/dispatch-production.sh "$stage/app/scripts/notifications/"
 chmod 0755 "$stage/app/scripts/deploy/reconfigure-webserver.sh"
+chmod 0755 "$stage/app/scripts/notifications/dispatch-production.sh"
 printf '%s\n' "$commit" > "$stage/app/DEPLOYED_COMMIT"
 tar -C "$stage" -czf "$output" app
 archive_contents="$stage/archive-contents.txt"
 tar -tzf "$output" > "$archive_contents"
 grep -Fxq 'app/scripts/deploy/reconfigure-webserver.sh' "$archive_contents"
+grep -Fxq 'app/scripts/notifications/dispatch-production.sh' "$archive_contents"

--- a/scripts/notifications/dispatch-production.sh
+++ b/scripts/notifications/dispatch-production.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+state_file="${NOTIFICATION_SCHEDULER_STATE_FILE:-/opt/festival-radar/shared/notification-scheduler-state.json}"
+lock_file="${NOTIFICATION_SCHEDULER_LOCK_FILE:-/run/festival-radar-notifications/dispatch.lock}"
+app_url="${APP_URL:-http://127.0.0.1:3100}"
+
+test -n "${INTERNAL_API_SECRET:-}" || { echo "INTERNAL_API_SECRET is required" >&2; exit 2; }
+exec 9>"$lock_file"
+flock -n 9 || { echo "notification dispatch already running"; exit 0; }
+
+started_at="$(date -u +%FT%TZ)"
+response_file="$(mktemp)"
+state_tmp="$(mktemp "$(dirname "$state_file")/.notification-scheduler-state.XXXXXX")"
+trap 'rm -f "$response_file" "$state_tmp"' EXIT
+
+if curl --fail-with-body --silent --show-error --max-time 240 \
+  -H "authorization: Bearer $INTERNAL_API_SECRET" \
+  -H "content-type: application/json" \
+  --data '{"limit":500}' \
+  "${app_url%/}/api/notifications/dispatch/" >"$response_file"; then
+  finished_at="$(date -u +%FT%TZ)"
+  "$NODE_BINARY" - "$response_file" "$started_at" "$finished_at" >"$state_tmp" <<'NODE'
+const [file, startedAt, finishedAt] = process.argv.slice(2);
+const result = JSON.parse(require("node:fs").readFileSync(file, "utf8"));
+const statuses = (result.results || []).reduce((out, item) => {
+  out[item.status] = (out[item.status] || 0) + 1;
+  return out;
+}, {});
+process.stdout.write(JSON.stringify({ startedAt, finishedAt, ok: true, processed: result.processed, statuses }) + "\n");
+NODE
+  chmod 0640 "$state_tmp"
+  mv -f "$state_tmp" "$state_file"
+  cat "$state_file"
+else
+  finished_at="$(date -u +%FT%TZ)"
+  printf '{"startedAt":"%s","finishedAt":"%s","ok":false}\n' "$started_at" "$finished_at" >"$state_tmp"
+  chmod 0640 "$state_tmp"
+  mv -f "$state_tmp" "$state_file"
+  exit 1
+fi

--- a/tests/notification-scheduler.test.mjs
+++ b/tests/notification-scheduler.test.mjs
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("production owns notification scheduling and GitHub is manual diagnostics only", async () => {
+  const [installer, workflow, runner, packager] = await Promise.all([
+    readFile("scripts/deploy/install-release.sh", "utf8"),
+    readFile(".github/workflows/notifications.yml", "utf8"),
+    readFile("scripts/notifications/dispatch-production.sh", "utf8"),
+    readFile("scripts/deploy/package-release.sh", "utf8"),
+  ]);
+  assert.match(installer, /OnUnitInactiveSec=10min/);
+  assert.match(installer, /Persistent=true/);
+  assert.match(installer, /systemctl enable --now "\$service-notifications.timer"/);
+  assert.doesNotMatch(workflow, /schedule:/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(runner, /flock -n/);
+  assert.match(runner, /authorization: Bearer \$INTERNAL_API_SECRET/);
+  assert.doesNotMatch(runner, /INTERNAL_API_SECRET.*state_file/);
+  assert.match(packager, /scripts\/notifications\/dispatch-production\.sh/);
+});


### PR DESCRIPTION
Closes #127

Moves the ten-minute notification dispatcher from unreliable GitHub scheduling to a production-owned persistent systemd timer. Adds overlap protection, aggregate non-secret run state, a stale health endpoint, deployment wiring, packaging coverage, and an operations runbook. GitHub retains manual diagnostics only.

Verification:
- `npm run typecheck`
- `npm run test:data` (116 JS + 4 TS tests)
- `npm run build` (278 routes)
- package-release archive contains the production scheduler runner
- shell syntax and diff checks pass

Production cadence and reversible delivery acceptance will be performed only in the later merge/deploy phase after every issue has an implementation PR.