### PR TITLE
Run analytics retention inside production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,11 +63,12 @@ jobs:
           APP_URL: ${{ secrets.APP_URL }}
           INTERNAL_API_SECRET: ${{ secrets.INTERNAL_API_SECRET }}
           ANALYTICS_OPERATOR_TOKEN: ${{ secrets.ANALYTICS_OPERATOR_TOKEN }}
+          ANALYTICS_RETENTION_TOKEN: ${{ secrets.ANALYTICS_RETENTION_TOKEN }}
           ANALYTICS_RETENTION_DAYS: ${{ vars.ANALYTICS_RETENTION_DAYS || '90' }}
           SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
           SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
         run: |
-          for name in DATABASE_URL AUTH_SECRET APP_URL INTERNAL_API_SECRET ANALYTICS_OPERATOR_TOKEN SPOTIFY_CLIENT_ID SPOTIFY_CLIENT_SECRET; do
+          for name in DATABASE_URL AUTH_SECRET APP_URL INTERNAL_API_SECRET ANALYTICS_OPERATOR_TOKEN ANALYTICS_RETENTION_TOKEN SPOTIFY_CLIENT_ID SPOTIFY_CLIENT_SECRET; do
             test -n "${!name}" || { echo "Missing required production secret: $name" >&2; exit 1; }
           done
           umask 077
@@ -77,6 +78,7 @@ jobs:
             printf 'APP_URL=%q\n' "$APP_URL"
             printf 'INTERNAL_API_SECRET=%q\n' "$INTERNAL_API_SECRET"
             printf 'ANALYTICS_OPERATOR_TOKEN=%q\n' "$ANALYTICS_OPERATOR_TOKEN"
+            printf 'ANALYTICS_RETENTION_TOKEN=%q\n' "$ANALYTICS_RETENTION_TOKEN"
             printf 'ANALYTICS_RETENTION_DAYS=%q\n' "$ANALYTICS_RETENTION_DAYS"
             printf 'SPOTIFY_CLIENT_ID=%q\n' "$SPOTIFY_CLIENT_ID"
             printf 'SPOTIFY_CLIENT_SECRET=%q\n' "$SPOTIFY_CLIENT_SECRET"

--- a/.github/workflows/prune-analytics.yml
+++ b/.github/workflows/prune-analytics.yml
@@ -18,14 +18,16 @@ jobs:
     environment: production
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
-      - run: npx prisma generate
-      - run: npm run analytics:prune
+      - name: Prune through production-local retention API
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          ANALYTICS_RETENTION_DAYS: ${{ vars.ANALYTICS_RETENTION_DAYS || '90' }}
+          APP_URL: ${{ secrets.APP_URL }}
+          ANALYTICS_RETENTION_TOKEN: ${{ secrets.ANALYTICS_RETENTION_TOKEN }}
+        run: |
+          test -n "$APP_URL"
+          test -n "$ANALYTICS_RETENTION_TOKEN"
+          response="$(curl --fail-with-body --silent --show-error --max-time 60 \
+            -X POST \
+            -H "authorization: Bearer $ANALYTICS_RETENTION_TOKEN" \
+            "${APP_URL%/}/api/analytics/prune/")"
+          jq -e '.deletedAggregateRows >= 0 and (.cutoff | type == "string") and (.retentionDays >= 1 and .retentionDays <= 730)' <<<"$response"
+          printf '%s\n' "$response"

--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ aggregate, non-identifying measurement is the documented consent policy; the
 site does not set analytics cookies or build visitor profiles.
 
 The receiver stores only daily `path`/`locale` counters in PostgreSQL. Set
-`ANALYTICS_RETENTION_DAYS` (90 by default) and run `npm run analytics:prune`
-daily. Reverse-proxy access logging for `/api/analytics/page-view` must be
+`ANALYTICS_RETENTION_DAYS` (90 by default) and configure the dedicated
+`ANALYTICS_RETENTION_TOKEN` used by the daily production retention workflow.
+The workflow invokes `/api/analytics/prune/`; database credentials remain
+inside production. Reverse-proxy access logging for `/api/analytics/page-view` must be
 disabled so IP addresses are not retained outside this schema. Operators can
 verify accepted counts without visitor data:
 

--- a/app/api/analytics/prune/route.ts
+++ b/app/api/analytics/prune/route.ts
@@ -1,0 +1,21 @@
+import { db } from "@/lib/db";
+import { pruneAnalytics } from "@/lib/analytics-retention";
+
+export const dynamic = "force-dynamic";
+const headers = { "cache-control": "no-store", "referrer-policy": "no-referrer" };
+
+export async function POST(request: Request) {
+  const token = process.env.ANALYTICS_RETENTION_TOKEN;
+  if (!token || request.headers.get("authorization") !== `Bearer ${token}`) {
+    return Response.json({ error: "Unauthorized." }, { status: 401, headers });
+  }
+
+  try {
+    return Response.json(await pruneAnalytics(db, process.env.ANALYTICS_RETENTION_DAYS), { headers });
+  } catch (cause) {
+    if (cause instanceof Error && cause.message.startsWith("ANALYTICS_RETENTION_DAYS")) {
+      return Response.json({ error: cause.message }, { status: 503, headers });
+    }
+    throw cause;
+  }
+}

--- a/lib/analytics-retention.ts
+++ b/lib/analytics-retention.ts
@@ -1,0 +1,28 @@
+type AnalyticsDb = {
+  analyticsDaily: {
+    deleteMany(args: { where: { day: { lt: Date } } }): Promise<{ count: number }>;
+  };
+};
+
+export function retentionDaysFrom(value?: string) {
+  const raw = value ?? "90";
+  const retentionDays = Number.parseInt(raw, 10);
+  if (!/^\d+$/.test(raw) || !Number.isInteger(retentionDays) || retentionDays < 1 || retentionDays > 730) {
+    throw new Error("ANALYTICS_RETENTION_DAYS must be an integer from 1 to 730");
+  }
+  return retentionDays;
+}
+
+export function analyticsCutoff(retentionDays: number, now = new Date()) {
+  const cutoff = new Date(now);
+  cutoff.setUTCHours(0, 0, 0, 0);
+  cutoff.setUTCDate(cutoff.getUTCDate() - retentionDays);
+  return cutoff;
+}
+
+export async function pruneAnalytics(db: AnalyticsDb, retentionValue?: string, now = new Date()) {
+  const retentionDays = retentionDaysFrom(retentionValue);
+  const cutoff = analyticsCutoff(retentionDays, now);
+  const result = await db.analyticsDaily.deleteMany({ where: { day: { lt: cutoff } } });
+  return { deletedAggregateRows: result.count, cutoff: cutoff.toISOString(), retentionDays };
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "timetables:import": "node scripts/import-timetable.mjs",
     "enrich:artists": "node scripts/enrich-artists.mjs",
     "resolve:artists": "node scripts/resolve-artist-identities.mjs",
-    "test:data": "node --test $(find tests -maxdepth 1 -name '*.test.mjs' ! -name '*.e2e.test.mjs' -print) && node --experimental-strip-types --test tests/selection-playlist.test.ts",
+    "test:data": "node --import tsx --test $(find tests -maxdepth 1 -name '*.test.mjs' ! -name '*.e2e.test.mjs' -print) && node --experimental-strip-types --test tests/selection-playlist.test.ts",
     "test:routes": "node scripts/test-locale-routes.mjs",
     "test:ingestion-db": "node --test tests/ingestion-repository.e2e.test.mjs",
     "test:integration": "node --test --test-concurrency=1 tests/integration/account-routes.test.mjs tests/integration/notification-routes.test.mjs tests/integration/admin-workflows.test.mjs",

--- a/tests/analytics-retention.test.mjs
+++ b/tests/analytics-retention.test.mjs
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { analyticsCutoff, pruneAnalytics, retentionDaysFrom } from "../lib/analytics-retention.ts";
+
+test("retention configuration accepts only whole days in the supported range", () => {
+  assert.equal(retentionDaysFrom(undefined), 90);
+  assert.equal(retentionDaysFrom("1"), 1);
+  assert.equal(retentionDaysFrom("730"), 730);
+  for (const value of ["0", "731", "1.5", "90days", "", "-2"]) {
+    assert.throws(() => retentionDaysFrom(value), /integer from 1 to 730/);
+  }
+});
+
+test("cutoff is an exclusive UTC day boundary", () => {
+  assert.equal(analyticsCutoff(90, new Date("2026-09-01T23:59:59Z")).toISOString(), "2026-06-03T00:00:00.000Z");
+});
+
+test("pruning uses the exclusive cutoff and reports deleted rows", async () => {
+  let received;
+  const db = { analyticsDaily: { async deleteMany(args) { received = args; return { count: 2 }; } } };
+  const result = await pruneAnalytics(db, "90", new Date("2026-09-01T12:00:00Z"));
+  assert.deepEqual(received, { where: { day: { lt: new Date("2026-06-03T00:00:00.000Z") } } });
+  assert.deepEqual(result, { deletedAggregateRows: 2, cutoff: "2026-06-03T00:00:00.000Z", retentionDays: 90 });
+});
+
+test("zero-deletion pruning is successful and idempotent", async () => {
+  const db = { analyticsDaily: { async deleteMany() { return { count: 0 }; } } };
+  assert.equal((await pruneAnalytics(db, "30")).deletedAggregateRows, 0);
+  assert.equal((await pruneAnalytics(db, "30")).deletedAggregateRows, 0);
+});

--- a/tests/internal-api-workflows.test.mjs
+++ b/tests/internal-api-workflows.test.mjs
@@ -47,10 +47,19 @@ test("deployment builds and installs the privacy analytics contract", async () =
   const pruneWorkflow = await readFile(".github/workflows/prune-analytics.yml", "utf8");
   assert.match(workflow, /NEXT_PUBLIC_ANALYTICS_ENDPOINT: \/api\/analytics\/page-view\//);
   assert.match(workflow, /ANALYTICS_OPERATOR_TOKEN: \$\{\{ secrets\.ANALYTICS_OPERATOR_TOKEN \}\}/);
+  assert.match(workflow, /ANALYTICS_RETENTION_TOKEN: \$\{\{ secrets\.ANALYTICS_RETENTION_TOKEN \}\}/);
   assert.match(workflow, /printf 'ANALYTICS_OPERATOR_TOKEN=%q\\n'/);
   assert.match(workflow, /printf 'ANALYTICS_RETENTION_DAYS=%q\\n'/);
   assert.match(pruneWorkflow, /environment: production/);
-  assert.match(pruneWorkflow, /DATABASE_URL: \$\{\{ secrets\.DATABASE_URL \}\}/);
+  assert.doesNotMatch(pruneWorkflow, /DATABASE_URL/);
+  assert.match(pruneWorkflow, /ANALYTICS_RETENTION_TOKEN: \$\{\{ secrets\.ANALYTICS_RETENTION_TOKEN \}\}/);
+  assert.match(pruneWorkflow, /\/api\/analytics\/prune\//);
+});
+
+test("analytics retention route fails closed behind its dedicated secret", async () => {
+  const route = await readFile("app/api/analytics/prune/route.ts", "utf8");
+  assert.match(route, /!token \|\| request\.headers\.get\("authorization"\) !== `Bearer \$\{token\}`/);
+  assert.match(route, /pruneAnalytics\(db, process\.env\.ANALYTICS_RETENTION_DAYS\)/);
 });
 
 for (const routeName of ["events", "dispatch"]) {


### PR DESCRIPTION
Closes #137

## Summary
- replace direct hosted-runner database access with a dedicated authenticated production API
- keep the production database URL confined to the deployed application
- validate the UTC cutoff and fail closed for missing/invalid configuration
- cover authorization contract, cutoff boundary, invalid values and idempotent zero-deletion

## Verification
- `npm run typecheck`
- `npm run test:data` (120 JavaScript + 4 TypeScript tests)
- `npm run build` (278 routes, including `/api/analytics/prune`)
- `git diff --check`

Production acceptance is intentionally deferred to the ordered merge phase.