### PR TITLE
Configure both Plesk proxy vhosts

### DIFF
--- a/scripts/deploy/install-release.sh
+++ b/scripts/deploy/install-release.sh
@@ -182,8 +182,9 @@ Unit=$service-analytics-retention.service
 WantedBy=timers.target
 UNIT
 
-vhost="/var/www/vhosts/system/$domain/conf/vhost.conf"
-install -d -m 0755 "$(dirname "$vhost")"
+vhost_directory="/var/www/vhosts/system/$domain/conf"
+install -d -m 0755 "$vhost_directory"
+for vhost in "$vhost_directory/vhost.conf" "$vhost_directory/vhost_ssl.conf"; do
 cat > "$vhost" <<APACHE
 ProxyPreserveHost On
 ProxyPass / http://127.0.0.1:$port/
@@ -198,6 +199,7 @@ RequestHeader set X-Forwarded-Proto "https" env=HTTPS
   </LocationMatch>
 </IfModule>
 APACHE
+done
 
 # Privacy analytics bypasses both nginx and Apache access logs. The exact
 # locations proxy directly to the loopback application and deliberately omit

--- a/tests/deploy-reconfigure.test.mjs
+++ b/tests/deploy-reconfigure.test.mjs
@@ -36,6 +36,19 @@ test("release activation explicitly restarts an already-running service", async 
   assert.doesNotMatch(installer, /systemctl enable --now "\$service"/);
 });
 
+test("release activation configures both Plesk HTTP and HTTPS virtual hosts", async () => {
+  const installer = await readFile("scripts/deploy/install-release.sh", "utf8");
+
+  assert.match(installer, /for vhost in "\$vhost_directory\/vhost\.conf" "\$vhost_directory\/vhost_ssl\.conf"/);
+  assert.match(installer, /ProxyPass \/ http:\/\/127\.0\.0\.1:\$port\//);
+  assert.match(installer, /ProxyPassReverse \/ http:\/\/127\.0\.0\.1:\$port\//);
+  assert.match(installer, /RequestHeader set X-Forwarded-Proto "https" env=HTTPS/);
+  const vhostTemplate = installer.indexOf('cat > "$vhost"');
+  const loopEnd = installer.indexOf("\ndone\n", vhostTemplate);
+  const nginxVhost = installer.indexOf('nginx_vhost="', loopEnd);
+  assert.ok(vhostTemplate >= 0 && loopEnd > vhostTemplate && nginxVhost > loopEnd);
+});
+
 test("release activation stages the new environment and rollback restores the previous one", async () => {
   const installer = await readFile("scripts/deploy/install-release.sh", "utf8");
 


### PR DESCRIPTION
Closes #98

## Summary
- write equivalent reverse-proxy directives to both Plesk `vhost.conf` and `vhost_ssl.conf`
- retain one canonical proxy template for both generated Apache virtual hosts
- add regression coverage for both include files

## Verification
- `node --test tests/deploy-reconfigure.test.mjs`
- `npm run test:data` (116 JavaScript + 4 TypeScript tests)
- `npm run typecheck`
- `npm run build` (277 pages)
- `bash -n scripts/deploy/install-release.sh scripts/deploy/reconfigure-webserver.sh`
- `git diff --check`

Production acceptance is deferred to the ordered milestone merge phase.