### PR TITLE
Fix scoped ingestion acceptance validation

### DIFF
--- a/.github/workflows/ingestion.yml
+++ b/.github/workflows/ingestion.yml
@@ -40,7 +40,8 @@ jobs:
             -H "content-type: application/json" \
             --data-binary @request.json \
             "${APP_URL%/}/api/ingestion/run/" | tee outputs/ingestion-response.json
-          jq -e '.runId and (.summary.attempted > 0) and (.readBack.attempts == .summary.attempted) and (.summary.status == "COMPLETED" or .summary.status == "PARTIAL") and (if env.FORCE == "true" then (.summary.totalSources == 50 and .summary.attempted == 50 and .readBack.candidates > 0 and .readBack.evidence > 0 and .readBack.diffs > 0 and .readBack.hasPersistedFailure and .readBack.lastSuccessfulCheck) else true end)' outputs/ingestion-response.json
+          jq -e --arg festival "$FESTIVAL" --argjson force "$FORCE" \
+            -f scripts/validate-ingestion-response.jq outputs/ingestion-response.json
       - name: Retain review and diagnostic artifacts
         if: always()
         uses: actions/upload-artifact@v4

--- a/scripts/validate-ingestion-response.jq
+++ b/scripts/validate-ingestion-response.jq
@@ -1,0 +1,28 @@
+.runId
+and (.summary.attempted > 0)
+and (.readBack.attempts == .summary.attempted)
+and (.summary.status == "COMPLETED" or .summary.status == "PARTIAL")
+and (
+  if $festival != "" then
+    .summary.totalSources == 1
+    and .summary.attempted == 1
+    and .readBack.attempts == 1
+    and .readBack.candidates == 1
+    and .readBack.evidence > 0
+    and .readBack.lastSuccessfulCheck
+    and (.summary.results | length == 1)
+    and .summary.results[0].festivalSlug == $festival
+    and (.summary.results[0].extractionPath | type == "array" and length > 0)
+    and (.summary.results[0].evidenceFields | type == "array" and length > 0)
+  elif $force then
+    .summary.totalSources == 50
+    and .summary.attempted == 50
+    and .readBack.candidates > 0
+    and .readBack.evidence > 0
+    and .readBack.diffs > 0
+    and .readBack.hasPersistedFailure
+    and .readBack.lastSuccessfulCheck
+  else
+    true
+  end
+)

--- a/tests/ingestion-publication.test.mjs
+++ b/tests/ingestion-publication.test.mjs
@@ -79,7 +79,8 @@ test("source failures above the explicit policy threshold remain fatal", async (
 
 test("workflow keeps auditable publication and artifact handling after accepted partial runs", async () => {
   const workflow = await readFile(".github/workflows/ingestion.yml", "utf8");
+  const validation = await readFile("scripts/validate-ingestion-response.jq", "utf8");
   assert.match(workflow, /api\/ingestion\/run\//);
-  assert.match(workflow, /summary\.status == "COMPLETED" or \.summary\.status == "PARTIAL"/);
+  assert.match(validation, /summary\.status == "COMPLETED" or \.summary\.status == "PARTIAL"/);
   assert.match(workflow, /name: Retain review and diagnostic artifacts[\s\S]*if: always\(\)/);
 });

--- a/tests/internal-api-workflows.test.mjs
+++ b/tests/internal-api-workflows.test.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
+import { promisify } from "node:util";
+
+const execute = promisify(execFile);
 
 for (const workflowName of ["notifications", "ingestion"]) {
   test(`${workflowName} uses production-scoped internal API credentials`, async () => {
@@ -24,8 +30,45 @@ test("ingestion keeps database access inside production and uses the canonical i
   assert.match(workflow, /"\$\{APP_URL%\/\}\/api\/ingestion\/run\/"/);
   assert.match(workflow, /mkdir -p outputs/);
   assert.match(workflow, /--argjson force "\$FORCE"/);
-  assert.match(workflow, /jq -e '\.runId and \(\.summary\.attempted > 0\)[\s\S]*\.readBack\.attempts == \.summary\.attempted/);
-  assert.match(workflow, /\.summary\.totalSources == 50[\s\S]*\.readBack\.diffs > 0[\s\S]*\.readBack\.hasPersistedFailure[\s\S]*\.readBack\.lastSuccessfulCheck/);
+  assert.match(workflow, /scripts\/validate-ingestion-response\.jq/);
+});
+
+test("ingestion workflow validates scoped and full-catalogue responses independently", async () => {
+  const validate = async (response, festival, force = true) => {
+    const directory = await mkdtemp(path.join(tmpdir(), "ingestion-validation-"));
+    const responsePath = path.join(directory, "response.json");
+    try {
+      await writeFile(responsePath, JSON.stringify(response));
+      const { stdout } = await execute("jq", [
+        "-e",
+        "--arg", "festival", festival,
+        "--argjson", "force", String(force),
+        "-f", "scripts/validate-ingestion-response.jq",
+        responsePath,
+      ]);
+      return stdout.trim();
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  };
+  const scoped = {
+    runId: "scoped-run",
+    summary: {
+      status: "COMPLETED", totalSources: 1, attempted: 1,
+      results: [{ festivalSlug: "pinkpop", extractionPath: ["official_markup"], evidenceFields: ["startDate"] }],
+    },
+    readBack: { attempts: 1, candidates: 1, evidence: 1, diffs: 0, hasPersistedFailure: false, lastSuccessfulCheck: "2026-08-31T16:34:00Z" },
+  };
+  assert.equal(await validate(scoped, "pinkpop"), "true");
+  await assert.rejects(validate({ ...scoped, summary: { ...scoped.summary, results: [{ ...scoped.summary.results[0], extractionPath: [] }] } }, "pinkpop"));
+
+  const full = {
+    runId: "full-run",
+    summary: { status: "PARTIAL", totalSources: 50, attempted: 50, results: [] },
+    readBack: { attempts: 50, candidates: 48, evidence: 55, diffs: 108, hasPersistedFailure: true, lastSuccessfulCheck: "2026-08-31T10:46:50Z" },
+  };
+  assert.equal(await validate(full, ""), "true");
+  await assert.rejects(validate({ ...full, readBack: { ...full.readBack, diffs: 0 } }, ""));
 });
 
 test("forced ingestion bypasses adaptive due filtering for full acceptance runs", async () => {


### PR DESCRIPTION
Closes #133

## Summary
- validate explicitly scoped manual ingestion runs against a one-source durable contract
- preserve the full 50-source forced acceptance contract for unscoped runs
- execute regression fixtures for both contracts and their failure cases
- rebased onto current `main` without weakening authorization or persistence checks

## Verification
- focused ingestion/workflow tests: 20/20
- `npm run test:data`: 131 JavaScript + 4 TypeScript tests
- fresh PostgreSQL 16 ingestion persistence: 1/1
- `npm run typecheck`
- Python: 60/60
- production build: 278/278 routes
- `git diff --check`

## Production acceptance
- scoped workflow [run 33528484698](https://github.com/KirDE/festival-radar/actions/runs/33528484698) succeeded on exact head `c5d84f8e2a23dfe46add90a31d5df293dfbff042`
- Pinkpop: `COMPLETED`, 1/1 attempted, 1 durable candidate, 3 evidence rows, adapter `official_markup`, persisted last-success present
