### PR TITLE
Preserve locale on artist routes

### DIFF
--- a/app/[lang]/artists/[slug]/page.tsx
+++ b/app/[lang]/artists/[slug]/page.tsx
@@ -1,0 +1,39 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import type { Language } from "@/components/LanguageProvider";
+import { ArtistDetail } from "@/components/ArtistDetail";
+import { artistProfiles, getArtistProfile } from "@/data/artists";
+import { festivals, supportedLanguages } from "@/data/festivals";
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return supportedLanguages.flatMap((lang) => artistProfiles.map(({ slug }) => ({ lang, slug })));
+}
+
+export async function generateMetadata({ params }: { params: Promise<{ lang: string; slug: string }> }): Promise<Metadata> {
+  const { lang, slug } = await params;
+  const artist = getArtistProfile(slug);
+  if (!artist || !supportedLanguages.includes(lang as Language)) return {};
+  return {
+    title: artist.name,
+    alternates: {
+      canonical: `/${lang}/artists/${artist.slug}/`,
+      languages: {
+        "x-default": `/artists/${artist.slug}/`,
+        en: `/en/artists/${artist.slug}/`,
+        de: `/de/artists/${artist.slug}/`,
+        ru: `/ru/artists/${artist.slug}/`,
+      },
+    },
+  };
+}
+
+export default async function LocalizedArtistPage({ params }: { params: Promise<{ lang: string; slug: string }> }) {
+  const { lang, slug } = await params;
+  if (!supportedLanguages.includes(lang as Language)) notFound();
+  const artist = getArtistProfile(slug);
+  if (!artist) notFound();
+  const appearances = festivals.filter((festival) => [...festival.headliners, ...festival.lineup].includes(artist.name));
+  return <ArtistDetail artist={artist} appearances={appearances} />;
+}

--- a/app/[lang]/festivals/[slug]/page.tsx
+++ b/app/[lang]/festivals/[slug]/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import type { Language } from "@/components/LanguageProvider";
+import { FestivalDetail } from "@/components/FestivalDetail";
+import { festivals, getFestival, supportedLanguages } from "@/data/festivals";
+import { festivalMusicEvent } from "@/lib/seo";
+
+export const dynamicParams = false;
+export function generateStaticParams() { return supportedLanguages.flatMap((lang) => festivals.map(({ slug }) => ({ lang, slug }))); }
+
+export async function generateMetadata({ params }: { params: Promise<{ lang: string; slug: string }> }): Promise<Metadata> {
+  const { lang, slug } = await params;
+  const festival = getFestival(slug);
+  if (!festival || !supportedLanguages.includes(lang as Language)) return {};
+  return { title: festival.name, alternates: { canonical: `/${lang}/festivals/${festival.slug}/`, languages: { "x-default": `/festivals/${festival.slug}/`, en: `/en/festivals/${festival.slug}/`, de: `/de/festivals/${festival.slug}/`, ru: `/ru/festivals/${festival.slug}/` } } };
+}
+
+export default async function LocalizedFestivalPage({ params }: { params: Promise<{ lang: string; slug: string }> }) {
+  const { lang, slug } = await params;
+  if (!supportedLanguages.includes(lang as Language)) notFound();
+  const item = getFestival(slug);
+  if (!item) notFound();
+  const event = festivalMusicEvent(item);
+  return <><script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(event).replace(/</g, "\\u003c") }} /><FestivalDetail item={item} /></>;
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -7,7 +7,7 @@ import { useLanguage } from "./LanguageProvider";
 export function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const { t, ta } = useLanguage();
-  const admin = pathname.startsWith("/admin");
+  const admin = pathname?.startsWith("/admin") ?? false;
 
   return <>
     <a className="skipLink" href="#main-content">{admin ? ta("skip") : t("skip")}</a>

--- a/components/ArtistDetail.tsx
+++ b/components/ArtistDetail.tsx
@@ -22,7 +22,7 @@ export function ArtistDetail({
       : `${appearances.length} ${festivalWord} ${t("announcedFor")}`;
   return (
     <div className="artistPage">
-      <Link className="back" href="/">
+      <Link className="back" href={`/${language}/`}>
         ← {t("festivalDirectory")}
       </Link>
       <FavoriteButton kind="artist" value={artist.name} />
@@ -98,7 +98,7 @@ export function ArtistDetail({
       <section className="appearances">
         <div className="eyebrow">{t("appearances")}</div>
         {appearances.map((festival) => (
-          <Link href={`/festivals/${festival.slug}/`} key={festival.slug}>
+          <Link href={`/${language}/festivals/${festival.slug}/`} key={festival.slug}>
             <span>{festival.countryCode}</span>
             <strong>{festival.name}</strong>
             <em>{festival.city}</em>

--- a/components/FestivalDetail.tsx
+++ b/components/FestivalDetail.tsx
@@ -16,7 +16,7 @@ import {
 } from "./LocalPlanner";
 
 export function FestivalDetail({ item }: { item: Festival }) {
-  const { locale, t } = useLanguage();
+  const { language, locale, t } = useLanguage();
   const planner = useLocalPlanner();
   const displayNames = new Intl.DisplayNames([locale], { type: "region" });
   const prettyDate = (value: string) =>
@@ -38,7 +38,7 @@ export function FestivalDetail({ item }: { item: Festival }) {
   const playlistUrl = playlist?.spotifyUrl || item.playlistUrl;
   return (
     <div className="detailPage">
-      <Link className="back" href="/">
+      <Link className="back" href={`/${language}/`}>
         ← {t("allFestivals")}
       </Link>
       <section className="detailHero">
@@ -74,7 +74,7 @@ export function FestivalDetail({ item }: { item: Festival }) {
           <option value="maybe">Maybe</option>
           <option value="not-going">Not going</option>
         </select>
-        <Link href="/planner/">Open my plan →</Link>
+        <Link href={`/${language}/planner/`}>Open my plan →</Link>
       </section>
       <div className="actionGrid">
         <a href={item.officialUrl} target="_blank" rel="noreferrer">
@@ -134,7 +134,7 @@ export function FestivalDetail({ item }: { item: Festival }) {
             <h3>{t("headliners")}</h3>
             <div className="headlinerGrid">
               {item.headliners.map((artist) => (
-                <Link href={`/artists/${artistSlug(artist)}/`} key={artist}>
+                <Link href={`/${language}/artists/${artistSlug(artist)}/`} key={artist}>
                   {artist}
                   <span>{t("viewArtist")}</span>
                 </Link>
@@ -152,7 +152,7 @@ export function FestivalDetail({ item }: { item: Festival }) {
             <h3>{t("alsoAnnounced")}</h3>
             <div className="lineupGrid">
               {item.lineup.map((artist) => (
-                <Link href={`/artists/${artistSlug(artist)}/`} key={artist}>
+                <Link href={`/${language}/artists/${artistSlug(artist)}/`} key={artist}>
                   {artist}
                 </Link>
               ))}

--- a/components/LanguageProvider.tsx
+++ b/components/LanguageProvider.tsx
@@ -77,6 +77,15 @@ export function translate(language: Language, key: TranslationKey, values: Trans
   return Object.entries(values).reduce((text, [name, value]) => text.replaceAll(`{${name}}`, String(value)), translations[language][key] as string);
 }
 
+export function languagePath(pathname: string, language: Language) {
+  const normalized = pathname.startsWith("/") ? pathname : `/${pathname}`;
+  const localized = normalized.match(/^\/(?:en|de|ru)(\/.*|$)/)?.[1];
+  if (localized !== undefined) return `/${language}${localized || "/"}`;
+  if (normalized === "/") return `/${language}/`;
+  if (/^\/(?:artists|festivals)\/[^/]+\/?$/.test(normalized)) return `/${language}${normalized.endsWith("/") ? normalized : `${normalized}/`}`;
+  return `/${language}/`;
+}
+
 const localeMap: Record<Language, string> = { en: "en-US", de: "de-DE", ru: "ru-RU" };
 const LanguageContext = createContext<{ language: Language; locale: string; setLanguage: (language: Language) => void; t: (key: TranslationKey, values?: TranslationValues) => string; ta: (key: AdminTranslationKey) => string } | null>(null);
 
@@ -89,7 +98,7 @@ function browserLanguage(): Language {
 }
 
 export function languageDestination(pathname: string, selected: Language) {
-  return pathname === "/admin" || pathname.startsWith("/admin/") ? null : `/${selected}/`;
+  return pathname === "/admin" || pathname.startsWith("/admin/") ? null : languagePath(pathname, selected);
 }
 
 export function LanguageProvider({ children, initialLanguage }: { children: React.ReactNode; initialLanguage?: Language }) {

--- a/components/PrivacyAnalytics.tsx
+++ b/components/PrivacyAnalytics.tsx
@@ -10,7 +10,7 @@ export function PrivacyAnalytics() {
 
   useEffect(() => {
     const endpoint = process.env.NEXT_PUBLIC_ANALYTICS_ENDPOINT;
-    if (!endpoint || lastPath.current === pathname) return;
+    if (!endpoint || !pathname || lastPath.current === pathname) return;
     lastPath.current = pathname;
     sendPrivacyPageView({ endpoint, pathname, navigator, document });
   }, [pathname]);

--- a/scripts/test-locale-routes.mjs
+++ b/scripts/test-locale-routes.mjs
@@ -39,6 +39,23 @@ try {
     assert.equal(planner.status, 200);
     assert.match(await planner.text(), new RegExp(`<html lang="${lang}"`));
 
+    const enrichedArtist = await fetch(`${origin}/${lang}/artists/electric-callboy/`);
+    assert.equal(enrichedArtist.status, 200);
+    const enrichedHtml = await enrichedArtist.text();
+    assert.match(enrichedHtml, new RegExp(`<html lang="${lang}"`));
+    assert.ok(enrichedHtml.includes({ en: "Recent setlists", de: "Aktuelle Setlists", ru: "Недавние сетлисты" }[lang]));
+    assert.ok(enrichedHtml.includes(`href="/${lang}/"`));
+
+    const partialArtist = await fetch(`${origin}/${lang}/artists/abbie-falls/`);
+    assert.equal(partialArtist.status, 200);
+    assert.match(await partialArtist.text(), new RegExp(`<html lang="${lang}"`));
+
+    const festival = await fetch(`${origin}/${lang}/festivals/wacken-open-air/`);
+    assert.equal(festival.status, 200);
+    const festivalHtml = await festival.text();
+    assert.match(festivalHtml, new RegExp(`<html lang="${lang}"`));
+    assert.ok(festivalHtml.includes(`href="/${lang}/artists/electric-callboy/"`));
+
     const manifest = await fetch(`${origin}/${lang}/manifest.webmanifest`);
     assert.equal(manifest.status, 200);
     const pwa = await manifest.json();

--- a/tests/artist-localization.test.mjs
+++ b/tests/artist-localization.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 
 const provider = await readFile(new URL("../components/LanguageProvider.tsx", import.meta.url), "utf8");
 const artistDetail = await readFile(new URL("../components/ArtistDetail.tsx", import.meta.url), "utf8");
+const providerRoute = await readFile(new URL("../app/[lang]/artists/[slug]/page.tsx", import.meta.url), "utf8");
 
 const expected = {
   en: ["Also known as", "Profile", "Origin", "Genres", "Top tracks", "Sources and canonical identities", "checked", "Recent setlists", "View setlist", "Profile refreshed every"],
@@ -17,6 +18,14 @@ test("artist enrichment labels are complete when switching every supported langu
     assert.ok(languageBlock, `${language} translation catalog is present`);
     for (const label of labels) assert.match(languageBlock[1], new RegExp(label), `${language} includes ${label}`);
   }
+});
+
+test("artist routes and links preserve every supported locale", () => {
+  assert.match(provider, /languageDestination\(window\.location\.pathname, selected\)/);
+  assert.match(provider, /languagePath\(pathname, selected\)/);
+  assert.match(providerRoute, /supportedLanguages\.flatMap/);
+  assert.match(providerRoute, /canonical: `\/\$\{lang\}\/artists\/\$\{artist\.slug\}\//);
+  assert.match(artistDetail, /href=\{`\/\$\{language\}\//);
 });
 
 test("artist enrichment UI renders all labels through LanguageProvider", () => {

--- a/tests/e2e/artist-localization.spec.mjs
+++ b/tests/e2e/artist-localization.spec.mjs
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+
+const locales = {
+  en: { recentSetlists: "Recent setlists", profile: "Profile" },
+  de: { recentSetlists: "Aktuelle Setlists", profile: "Profil" },
+  ru: { recentSetlists: "Недавние сетлисты", profile: "Профиль" },
+};
+
+for (const [language, labels] of Object.entries(locales)) {
+  test(`${language} artist routes survive navigation and direct reload`, async ({ page }) => {
+    await page.goto(`/${language}/festivals/wacken-open-air/`);
+    await expect(page.locator("html")).toHaveAttribute("lang", language);
+    await page.locator(`a[href="/${language}/artists/electric-callboy/"]`).first().click();
+    await expect(page).toHaveURL(new RegExp(`/${language}/artists/electric-callboy/$`));
+    await expect(page.getByText(labels.recentSetlists, { exact: true })).toBeVisible();
+
+    await page.reload();
+    await expect(page.locator("html")).toHaveAttribute("lang", language);
+    await expect(page.getByText(labels.profile, { exact: true })).toBeVisible();
+
+    await page.goto(`/${language}/artists/abbie-falls/`);
+    await expect(page.locator("html")).toHaveAttribute("lang", language);
+    await expect(page.getByText(labels.profile, { exact: true })).toBeVisible();
+  });
+}
+
+test("language switching preserves the current artist", async ({ page }) => {
+  await page.goto("/en/artists/electric-callboy/");
+
+  for (const language of ["de", "ru", "en"]) {
+    const picker = page.locator(".languagePicker select");
+    await expect.poll(() => picker.evaluate((element) => Object.keys(element).some((key) => key.startsWith("__reactProps")))).toBe(true);
+    await picker.selectOption(language);
+    await expect(page).toHaveURL(new RegExp(`/${language}/artists/electric-callboy/$`));
+    await expect(page.locator("html")).toHaveAttribute("lang", language);
+    await expect(page.getByText(locales[language].recentSetlists, { exact: true })).toBeVisible();
+  }
+});


### PR DESCRIPTION
Closes #136

Adds locale-aware artist and festival detail routes, keeps artist/festival navigation in the active locale, and preserves the current detail path when switching languages. Retains the Admin Console language-switch behavior from #160.

Verification:

- 131 JavaScript data/deployment tests + 4 TypeScript selection tests
- TypeScript typecheck
- production build (785 routes)
- EN/DE/RU production route smoke for enriched and partial artist profiles plus localized festival-to-artist links
- Playwright browser coverage for EN/DE/RU navigation, direct reload, partial profiles, and same-artist language switching (4/4)
- git diff --check