### PR TITLE
Fix privileged deployment asset upgrades

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -85,6 +85,7 @@ jobs:
           } > production.env
       - name: Upload and activate release
         run: |
+          ssh production sudo -n /usr/local/libexec/festival-radar/upgrade-deployment-assets "$GITHUB_SHA"
           ssh production 'test "$(id -un)" = festival-radar-deploy && sudo -n /usr/local/libexec/festival-radar/activate-release 0000000000000000000000000000000000000000 2>&1 | grep -Fq "missing regular deployment input"'
           scp release.tar.gz "production:/var/lib/festival-radar-deploy/incoming/$GITHUB_SHA.tar.gz"
           scp production.env "production:/var/lib/festival-radar-deploy/incoming/$GITHUB_SHA.env"

--- a/scripts/deploy/bootstrap-deploy-user.sh
+++ b/scripts/deploy/bootstrap-deploy-user.sh
@@ -14,6 +14,10 @@ install -o "$deploy_user" -g "$deploy_user" -m 0600 "$public_key" "$home/.ssh/au
 install -d -o root -g root -m 0755 /usr/local/libexec/festival-radar
 install -o root -g root -m 0755 scripts/deploy/install-release.sh /usr/local/libexec/festival-radar/install-release.sh
 install -o root -g root -m 0755 scripts/deploy/activate-release /usr/local/libexec/festival-radar/activate-release
-printf '%s\n' 'festival-radar-deploy ALL=(root) NOPASSWD: /usr/local/libexec/festival-radar/activate-release [0-9a-f]*' > /etc/sudoers.d/festival-radar-deploy
+install -o root -g root -m 0755 scripts/deploy/upgrade-deployment-assets /usr/local/libexec/festival-radar/upgrade-deployment-assets
+printf '%s\n' \
+  'festival-radar-deploy ALL=(root) NOPASSWD: /usr/local/libexec/festival-radar/activate-release [0-9a-f]*' \
+  'festival-radar-deploy ALL=(root) NOPASSWD: /usr/local/libexec/festival-radar/upgrade-deployment-assets [0-9a-f]*' \
+  > /etc/sudoers.d/festival-radar-deploy
 chmod 0440 /etc/sudoers.d/festival-radar-deploy
 visudo -cf /etc/sudoers.d/festival-radar-deploy

--- a/scripts/deploy/upgrade-deployment-assets
+++ b/scripts/deploy/upgrade-deployment-assets
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+commit="${1:?usage: upgrade-deployment-assets COMMIT}"
+deploy_user="festival-radar-deploy"
+repository="KirDE/festival-radar"
+destination="/usr/local/libexec/festival-radar"
+
+[[ "$commit" =~ ^[0-9a-f]{40}$ ]] || { echo "invalid commit" >&2; exit 2; }
+[[ "${SUDO_USER:-}" == "$deploy_user" ]] || { echo "unauthorized deploy caller" >&2; exit 3; }
+
+temporary="$(mktemp -d)"
+trap 'rm -rf "$temporary"' EXIT
+
+main_sha="$(curl --fail --silent --show-error --proto '=https' --tlsv1.2 \
+  --max-time 20 "https://api.github.com/repos/$repository/commits/main" \
+  | sed -n 's/.*"sha"[[:space:]]*:[[:space:]]*"\([0-9a-f]\{40\}\)".*/\1/p' \
+  | head -n 1)"
+[[ "$main_sha" == "$commit" ]] || { echo "commit is not the current main head" >&2; exit 4; }
+
+for asset in activate-release install-release.sh upgrade-deployment-assets; do
+  curl --fail --silent --show-error --proto '=https' --tlsv1.2 --max-time 20 \
+    "https://raw.githubusercontent.com/$repository/$commit/scripts/deploy/$asset" \
+    --output "$temporary/$asset"
+  test -s "$temporary/$asset"
+  bash -n "$temporary/$asset"
+done
+
+install -d -o root -g root -m 0755 "$destination"
+for asset in activate-release install-release.sh upgrade-deployment-assets; do
+  install -o root -g root -m 0755 "$temporary/$asset" "$destination/$asset"
+done
+printf '%s\n' "$commit" > "$destination/DEPLOYMENT_ASSETS_COMMIT"
+chmod 0644 "$destination/DEPLOYMENT_ASSETS_COMMIT"

--- a/tests/deploy-least-privilege.test.mjs
+++ b/tests/deploy-least-privilege.test.mjs
@@ -6,6 +6,7 @@ test("production workflow uses the constrained deploy identity and wrapper", asy
   const workflow = await readFile(".github/workflows/deploy.yml", "utf8");
   assert.match(workflow, /User festival-radar-deploy/);
   assert.match(workflow, /sudo -n \/usr\/local\/libexec\/festival-radar\/activate-release/);
+  assert.match(workflow, /sudo -n \/usr\/local\/libexec\/festival-radar\/upgrade-deployment-assets/);
   assert.doesNotMatch(workflow, /User root/);
   assert.doesNotMatch(workflow, /production:\/tmp/);
 });
@@ -13,8 +14,19 @@ test("production workflow uses the constrained deploy identity and wrapper", asy
 test("bootstrap grants only the reviewed activation wrapper", async () => {
   const bootstrap = await readFile("scripts/deploy/bootstrap-deploy-user.sh", "utf8");
   assert.match(bootstrap, /NOPASSWD: \/usr\/local\/libexec\/festival-radar\/activate-release/);
+  assert.match(bootstrap, /NOPASSWD: \/usr\/local\/libexec\/festival-radar\/upgrade-deployment-assets/);
   assert.doesNotMatch(bootstrap, /NOPASSWD:\s*ALL/);
   assert.match(bootstrap, /visudo -cf/);
+});
+
+test("privileged assets update only from the exact current main commit", async () => {
+  const updater = await readFile("scripts/deploy/upgrade-deployment-assets", "utf8");
+  assert.match(updater, /SUDO_USER/);
+  assert.match(updater, /commits\/main/);
+  assert.match(updater, /main_sha.*commit/);
+  assert.match(updater, /raw\.githubusercontent\.com/);
+  assert.match(updater, /bash -n/);
+  assert.doesNotMatch(updater, /eval|source /);
 });
 
 test("activation wrapper validates caller, commit, input type, and owner", async () => {


### PR DESCRIPTION
Closes #154

Adds a constrained root-owned updater that accepts only the exact current GitHub `main` SHA, downloads the three reviewed deployment assets over HTTPS, syntax-checks them, records the installed asset commit, and then permits normal activation. The deploy workflow runs this updater before every release, preventing privileged installer changes from being silently ignored.

Verification:
- `npm run typecheck`
- `npm run test:data` (117 JS + 4 TS tests)
- deployment shell syntax
- `git diff --check`