### PR TITLE
Fix production notification scheduler curl compatibility

### DIFF
--- a/scripts/notifications/dispatch-production.sh
+++ b/scripts/notifications/dispatch-production.sh
@@ -14,11 +14,14 @@ response_file="$(mktemp)"
 state_tmp="$(mktemp "$(dirname "$state_file")/.notification-scheduler-state.XXXXXX")"
 trap 'rm -f "$response_file" "$state_tmp"' EXIT
 
-if curl --fail-with-body --silent --show-error --max-time 240 \
+http_status=""
+if http_status="$(curl --silent --show-error --max-time 240 \
   -H "authorization: Bearer $INTERNAL_API_SECRET" \
   -H "content-type: application/json" \
   --data '{"limit":500}' \
-  "${app_url%/}/api/notifications/dispatch/" >"$response_file"; then
+  --output "$response_file" \
+  --write-out '%{http_code}' \
+  "${app_url%/}/api/notifications/dispatch/")" && [[ "$http_status" == 2?? ]]; then
   finished_at="$(date -u +%FT%TZ)"
   "$NODE_BINARY" - "$response_file" "$started_at" "$finished_at" >"$state_tmp" <<'NODE'
 const [file, startedAt, finishedAt] = process.argv.slice(2);
@@ -34,6 +37,11 @@ NODE
   cat "$state_file"
 else
   finished_at="$(date -u +%FT%TZ)"
+  if [[ -n "$http_status" && "$http_status" != "000" ]]; then
+    printf 'notification dispatch failed with HTTP %s\n' "$http_status" >&2
+  else
+    printf 'notification dispatch request failed before an HTTP response\n' >&2
+  fi
   printf '{"startedAt":"%s","finishedAt":"%s","ok":false}\n' "$started_at" "$finished_at" >"$state_tmp"
   chmod 0640 "$state_tmp"
   mv -f "$state_tmp" "$state_file"

--- a/tests/notification-scheduler.test.mjs
+++ b/tests/notification-scheduler.test.mjs
@@ -16,6 +16,9 @@ test("production owns notification scheduling and GitHub is manual diagnostics o
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(runner, /flock -n/);
   assert.match(runner, /authorization: Bearer \$INTERNAL_API_SECRET/);
+  assert.doesNotMatch(runner, /--fail-with-body/);
+  assert.match(runner, /--write-out '%\{http_code\}'/);
+  assert.match(runner, /\[\[ "\$http_status" == 2\?\? \]\]/);
   assert.doesNotMatch(runner, /INTERNAL_API_SECRET.*state_file/);
   assert.match(packager, /scripts\/notifications\/dispatch-production\.sh/);
 });


### PR DESCRIPTION
## Summary
- replace unsupported curl --fail-with-body with explicit HTTP status handling
- retain transport and non-2xx failures as scheduler failures without exposing the bearer secret
- prevent the unsupported production option from returning

Closes #156

## Verification
- bash -n scripts/notifications/dispatch-production.sh
- npm run test:data (117 JavaScript + 4 TypeScript tests)
- npm run typecheck
- npm run build
- git diff --check