### PR TITLE
Keep language switching inside Admin Console

### DIFF
--- a/components/LanguageProvider.tsx
+++ b/components/LanguageProvider.tsx
@@ -79,6 +79,10 @@ function browserLanguage(): Language {
   return "en";
 }
 
+export function languageDestination(pathname: string, selected: Language) {
+  return pathname === "/admin" || pathname.startsWith("/admin/") ? null : `/${selected}/`;
+}
+
 export function LanguageProvider({ children, initialLanguage }: { children: React.ReactNode; initialLanguage?: Language }) {
   const [language, updateLanguage] = useState<Language>(initialLanguage ?? "en");
   useEffect(() => {
@@ -92,7 +96,16 @@ export function LanguageProvider({ children, initialLanguage }: { children: Reac
     updateLanguage(selected);
     document.documentElement.lang = selected;
   }, [initialLanguage]);
-  const setLanguage = (selected: Language) => { localStorage.setItem("festival-radar-language", selected); window.location.assign(`/${selected}/`); };
+  const setLanguage = (selected: Language) => {
+    localStorage.setItem("festival-radar-language", selected);
+    const destination = languageDestination(window.location.pathname, selected);
+    if (destination) {
+      window.location.assign(destination);
+      return;
+    }
+    updateLanguage(selected);
+    document.documentElement.lang = selected;
+  };
   const value = useMemo(() => ({ language, locale: localeMap[language], setLanguage, t: (key: TranslationKey, values?: TranslationValues) => translate(language, key, values), ta: (key: AdminTranslationKey) => adminTranslations[language][key] }), [language]);
   return <LanguageContext.Provider value={value}>{children}</LanguageContext.Provider>;
 }

--- a/tests/admin-language.test.mjs
+++ b/tests/admin-language.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { languageDestination } from "../components/LanguageProvider.tsx";
+
+test("language changes stay inside every admin route", () => {
+  for (const path of ["/admin", "/admin/", "/admin/review", "/admin/assets/"]) {
+    assert.equal(languageDestination(path, "ru"), null);
+  }
+});
+
+test("language changes keep the existing public navigation behavior", () => {
+  assert.equal(languageDestination("/", "de"), "/de/");
+  assert.equal(languageDestination("/planner/", "ru"), "/ru/");
+});


### PR DESCRIPTION
Closes #160

## What changed
- keep EN/DE/RU changes on the current admin route
- update the live admin UI and document language in place
- preserve the existing public-site language navigation behavior
- add regression coverage for root and nested admin paths plus public paths

## Verification
- focused admin localization tests (5/5)
- npm run test:data (124 JS + 4 TS tests)
- npm run typecheck
- npm run build (278 routes)
- git diff --check