### PR TITLE
Preserve the admin allowlist across production deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,7 @@ jobs:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           AUTH_SECRET: ${{ secrets.AUTH_SECRET }}
           APP_URL: ${{ secrets.APP_URL }}
+          ADMIN_EMAILS: ${{ secrets.ADMIN_EMAILS }}
           INTERNAL_API_SECRET: ${{ secrets.INTERNAL_API_SECRET }}
           ANALYTICS_OPERATOR_TOKEN: ${{ secrets.ANALYTICS_OPERATOR_TOKEN }}
           ANALYTICS_RETENTION_TOKEN: ${{ secrets.ANALYTICS_RETENTION_TOKEN }}
@@ -68,7 +69,7 @@ jobs:
           SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
           SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
         run: |
-          for name in DATABASE_URL AUTH_SECRET APP_URL INTERNAL_API_SECRET ANALYTICS_OPERATOR_TOKEN ANALYTICS_RETENTION_TOKEN SPOTIFY_CLIENT_ID SPOTIFY_CLIENT_SECRET; do
+          for name in DATABASE_URL AUTH_SECRET APP_URL ADMIN_EMAILS INTERNAL_API_SECRET ANALYTICS_OPERATOR_TOKEN ANALYTICS_RETENTION_TOKEN SPOTIFY_CLIENT_ID SPOTIFY_CLIENT_SECRET; do
             test -n "${!name}" || { echo "Missing required production secret: $name" >&2; exit 1; }
           done
           umask 077
@@ -76,6 +77,7 @@ jobs:
             printf 'DATABASE_URL=%q\n' "$DATABASE_URL"
             printf 'AUTH_SECRET=%q\n' "$AUTH_SECRET"
             printf 'APP_URL=%q\n' "$APP_URL"
+            printf 'ADMIN_EMAILS=%q\n' "$ADMIN_EMAILS"
             printf 'INTERNAL_API_SECRET=%q\n' "$INTERNAL_API_SECRET"
             printf 'ANALYTICS_OPERATOR_TOKEN=%q\n' "$ANALYTICS_OPERATOR_TOKEN"
             printf 'ANALYTICS_RETENTION_TOKEN=%q\n' "$ANALYTICS_RETENTION_TOKEN"

--- a/tests/internal-api-workflows.test.mjs
+++ b/tests/internal-api-workflows.test.mjs
@@ -38,8 +38,16 @@ test("forced ingestion bypasses adaptive due filtering for full acceptance runs"
 test("deployment requires and installs the internal API secret", async () => {
   const workflow = await readFile(".github/workflows/deploy.yml", "utf8");
   assert.match(workflow, /INTERNAL_API_SECRET: \$\{\{ secrets\.INTERNAL_API_SECRET \}\}/);
-  assert.match(workflow, /for name in DATABASE_URL AUTH_SECRET APP_URL INTERNAL_API_SECRET/);
+  assert.match(workflow, /for name in DATABASE_URL AUTH_SECRET APP_URL ADMIN_EMAILS INTERNAL_API_SECRET/);
   assert.match(workflow, /printf 'INTERNAL_API_SECRET=%q\\n' "\$INTERNAL_API_SECRET"/);
+});
+
+test("deployment preserves the protected admin allowlist", async () => {
+  const workflow = await readFile(".github/workflows/deploy.yml", "utf8");
+  assert.match(workflow, /ADMIN_EMAILS: \$\{\{ secrets\.ADMIN_EMAILS \}\}/);
+  assert.match(workflow, /for name in DATABASE_URL AUTH_SECRET APP_URL ADMIN_EMAILS INTERNAL_API_SECRET/);
+  assert.match(workflow, /printf 'ADMIN_EMAILS=%q\\n' "\$ADMIN_EMAILS"/);
+  assert.doesNotMatch(workflow, /echo.*ADMIN_EMAILS/);
 });
 
 test("deployment builds and installs the privacy analytics contract", async () => {


### PR DESCRIPTION
Closes #166

## What changed
- require ADMIN_EMAILS as a production environment secret
- carry the allowlist into every protected production.env release file
- add regression coverage for the deployment contract
- configure the production environment secret through GitHub encrypted secret storage without exposing its value

## Verification
- GitHub production secret metadata read-back succeeded
- focused deployment contract tests: 13/13
- npm run test:data (129 JS + 4 TS tests)
- npm run typecheck
- npm run build (278 routes)
- git diff --check

## Production acceptance after merge
- confirm exact deployment SHA and database health
- confirm ADMIN_EMAILS key exists without printing it
- verify dummy ADMIN login/me/admin access
- repeat EN/DE/RU language-switch acceptance for #160