### PR TITLE
Exclude privacy analytics from proxy access logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,10 @@ The receiver stores only daily `path`/`locale` counters in PostgreSQL. Set
 `ANALYTICS_RETENTION_DAYS` (90 by default) and configure the dedicated
 `ANALYTICS_RETENTION_TOKEN` used by the daily production retention workflow.
 The workflow invokes `/api/analytics/prune/`; database credentials remain
-inside production. Reverse-proxy access logging for `/api/analytics/page-view` must be
-disabled so IP addresses are not retained outside this schema. Operators can
+inside production. Each release installs exact nginx locations for both
+`/api/analytics/page-view` spellings. Those locations disable access logging,
+proxy directly to the loopback application, and remove client-address forwarding
+so IP addresses are not retained outside this schema. Operators can
 verify accepted counts without visitor data:
 
 ```bash
@@ -133,7 +135,11 @@ curl -fsS -H "Authorization: Bearer $ANALYTICS_OPERATOR_TOKEN" \
 The response contains only the time window, total views and aggregate rows.
 Production verification is complete when a test page view returns HTTP 204,
 the total increments once after one route transition, and the database has no
-analytics rows older than the configured retention window.
+analytics rows older than the configured retention window. Record the current
+line counts of both Plesk proxy access logs, submit uniquely marked requests to
+the endpoint with and without the trailing slash, then confirm neither marker
+nor a new analytics request line appears while an ordinary control request is
+still logged.
 
 ## Main scripts
 

--- a/scripts/deploy/install-release.sh
+++ b/scripts/deploy/install-release.sh
@@ -145,6 +145,34 @@ ProxyPassReverse / http://127.0.0.1:$port/
 RequestHeader set X-Forwarded-Proto "https" env=HTTPS
 APACHE
 
+# Privacy analytics bypasses both nginx and Apache access logs. The exact
+# locations proxy directly to the loopback application and deliberately omit
+# client-address forwarding; query strings do not participate in nginx
+# location matching, so both endpoint spellings remain covered.
+nginx_vhost="/var/www/vhosts/system/$domain/conf/vhost_nginx.conf"
+cat > "$nginx_vhost" <<NGINX
+location = /api/analytics/page-view {
+    access_log off;
+    proxy_pass http://127.0.0.1:$port;
+    proxy_http_version 1.1;
+    proxy_set_header Host \$host;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+    proxy_set_header X-Real-IP "";
+    proxy_set_header X-Forwarded-For "";
+}
+
+location = /api/analytics/page-view/ {
+    access_log off;
+    proxy_pass http://127.0.0.1:$port;
+    proxy_http_version 1.1;
+    proxy_set_header Host \$host;
+    proxy_set_header X-Forwarded-Proto \$scheme;
+    proxy_set_header X-Real-IP "";
+    proxy_set_header X-Forwarded-For "";
+}
+NGINX
+chmod 0644 "$nginx_vhost"
+
 if [[ -f "$env_file" ]]; then
   cp -p "$env_file" "$previous_env"
   had_previous_env=true

--- a/tests/analytics-proxy-privacy.test.mjs
+++ b/tests/analytics-proxy-privacy.test.mjs
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("deploy excludes both analytics endpoint spellings from proxy access logs", async () => {
+  const installer = await readFile("scripts/deploy/install-release.sh", "utf8");
+  const privacyBlock = installer.slice(installer.indexOf('nginx_vhost="'), installer.indexOf('chmod 0644 "$nginx_vhost"'));
+  assert.match(privacyBlock, /vhost_nginx\.conf/);
+  assert.match(privacyBlock, /location = \/api\/analytics\/page-view \{/);
+  assert.match(privacyBlock, /location = \/api\/analytics\/page-view\/ \{/);
+  assert.equal((privacyBlock.match(/access_log off;/g) || []).length, 2);
+  assert.equal((privacyBlock.match(/proxy_pass http:\/\/127\.0\.0\.1:\$port;/g) || []).length, 2);
+  assert.equal((privacyBlock.match(/proxy_set_header X-Real-IP "";/g) || []).length, 2);
+  assert.equal((privacyBlock.match(/proxy_set_header X-Forwarded-For "";/g) || []).length, 2);
+  assert.ok(installer.indexOf('chmod 0644 "$nginx_vhost"') < installer.indexOf('reconfigure-webserver.sh'), "privacy config must be installed before Plesk reconfiguration");
+});


### PR DESCRIPTION
Closes #169.

Every release now installs exact nginx locations for both analytics page-view endpoint spellings. Those locations disable access logging, proxy directly to the loopback application, and clear client-address forwarding. Ordinary routes retain the normal Plesk proxy/logging path. The privacy configuration is installed before domain reconfiguration.

Verification:
- data tests: 131 JS + 4 TS
- TypeScript typecheck
- Python tests: 60/60
- production build: 278 routes
- installer bash syntax
- generated location block: nginx 1.27 configuration test successful

Production acceptance after merge must compare Plesk proxy-log line counts/unique markers for both endpoint spellings and an ordinary logged control request.