### PR TITLE
Recover trusted ingestion sources

### DIFF
--- a/data/festival-sources.ts
+++ b/data/festival-sources.ts
@@ -11,6 +11,9 @@ function source(festivalSlug: string, refreshPolicy: RefreshPolicy, strategies: 
 function manual(festivalSlug: string, reason: string): FestivalSource {
   return { ...source(festivalSlug, "weekly", ["manual_review"]), manualReviewReason: reason };
 }
+function retired(festivalSlug: string, reason: string): FestivalSource {
+  return { ...source(festivalSlug, "archived", ["manual_review"]), enabled: false, manualReviewReason: reason };
+}
 
 // Explicit inventory: adding a festival to the catalogue requires adding its source here.
 export const festivalSources: FestivalSource[] = [
@@ -30,7 +33,7 @@ export const festivalSources: FestivalSource[] = [
   source("bloodstock", "daily"),
   source("reading", "weekly"),
   source("leeds", "weekly"),
-  source("2000trees", "weekly"),
+  source("2000trees", "weekly", ["official_markup"]),
   source("graspop", "weekly"),
   source("rock-werchter", "weekly"),
   source("alcatraz", "weekly"),
@@ -63,6 +66,6 @@ export const festivalSources: FestivalSource[] = [
   manual("copenhell", "official home page has no stable authoritative date or location marker"),
   source("roskilde", "weekly"),
   manual("rockstadt", "official home page metadata has no authoritative current-edition date range"),
-  source("metaldays", "weekly"),
+  retired("metaldays", "the organizer ended MetalDays in 2024; no 2027 edition exists to monitor (catalogue correction tracked in #175)"),
 ];
 export function getFestivalSource(slug: string) { return festivalSources.find((item) => item.festivalSlug === slug); }

--- a/data/festivals.ts
+++ b/data/festivals.ts
@@ -84,7 +84,7 @@ const baseFestivals: Festival[] = [
   festival("bloodstock", "Bloodstock Open Air", "United Kingdom", "GB", "https://www.bloodstock.uk.com/", { city: "Walton-on-Trent", startDate: "2027-08-05", endDate: "2027-08-08", headliners: ["Mercyful Fate", "Electric Callboy", "Motionless In White"], lineup: ["Acid Bath", "Green Lung", "Children of Bodom", "DevilDriver", "Corrosion of Conformity", "Imminence", "Wind Rose", "Sylosis", "Decapitated", "Witch Club Satan", "HammerFall", "Hypocrisy", "The Halo Effect", "Tortured Demon", "Gutalax", "Humanity's Last Breath", "Conan", "Madball", "Gaerea", "Kanonenfieber", "Dethklok", "Dool", "Pig Destroyer", "Fulci"], status: "confirmed" }),
   festival("reading", "Reading Festival", "United Kingdom", "GB", "https://www.readingfestival.com/", { city: "Reading" }),
   festival("leeds", "Leeds Festival", "United Kingdom", "GB", "https://www.leedsfestival.com/", { city: "Leeds" }),
-  festival("2000trees", "2000trees", "United Kingdom", "GB", "https://www.twothousandtreesfestival.co.uk/", { city: "Cheltenham" }),
+  festival("2000trees", "2000trees", "United Kingdom", "GB", "https://2000trees.co.uk/", { city: "Cheltenham" }),
   festival("graspop", "Graspop Metal Meeting", "Belgium", "BE", "https://www.graspop.be/", { city: "Dessel" }),
   festival("rock-werchter", "Rock Werchter", "Belgium", "BE", "https://www.rockwerchter.be/", { city: "Werchter" }),
   festival("alcatraz", "Alcatraz Open Air", "Belgium", "BE", "https://www.alcatraz.be/", { city: "Kortrijk" }),

--- a/lib/ingestion/adapters/official-markup.ts
+++ b/lib/ingestion/adapters/official-markup.ts
@@ -19,12 +19,19 @@ function tuska(html: string): AdapterResult | undefined {
   return { startDate: `${date[4]}-${pad(date[3])}-${pad(date[1])}`, endDate: `${date[4]}-${pad(date[3])}-${pad(date[2])}`, excerpt: date[0] };
 }
 
+function trees(html: string): AdapterResult | undefined {
+  const date = html.match(/(\d{1,2})(?:st|nd|rd|th)\s*[-–—]\s*(\d{1,2})(?:st|nd|rd|th)\s+(January|February|March|April|May|June|July|August|September|October|November|December)\s+(20\d{2})/i);
+  if (!date) return undefined;
+  const month = String(new Date(`${date[3]} 1, 2000`).getUTCMonth() + 1).padStart(2, "0");
+  return { startDate: `${date[4]}-${month}-${pad(date[1])}`, endDate: `${date[4]}-${month}-${pad(date[2])}`, excerpt: date[0] };
+}
+
 function leyendas(html: string): AdapterResult | undefined {
   const title = html.match(/<title[^>]*>[\s\S]*?Leyendas del Rock\s+(20\d{2})[\s\S]*?<\/title>/i);
   return title ? { excerpt: title[0].replace(/<[^>]+>/g, " ").trim() } : undefined;
 }
 
-const adapters: Record<string, (html: string) => AdapterResult | undefined> = { "pinkpop": pinkpop, "tuska": tuska, "leyendas-del-rock": leyendas };
+const adapters: Record<string, (html: string) => AdapterResult | undefined> = { "2000trees": trees, "pinkpop": pinkpop, "tuska": tuska, "leyendas-del-rock": leyendas };
 
 export function extractOfficialMarkupCandidate(html: string, source: FestivalSource, fetchedAt: string): FestivalCandidate {
   const candidate: FestivalCandidate = { schemaVersion: INGESTION_SCHEMA_VERSION, festivalSlug: source.festivalSlug, sourceUrl: source.url, fetchedAt, evidence: [], warnings: [], observedEditionYears: [] };

--- a/tests/festival-data.test.mjs
+++ b/tests/festival-data.test.mjs
@@ -123,15 +123,19 @@ test("the production deploy smoke uses an existing artist profile", async () => 
   assert.ok(artistProfiles.some(({ slug }) => slug === match[1]), match[1]);
 });
 
-test("every festival has exactly one enabled ingestion source", () => {
+test("every festival has exactly one ingestion source and retired sources fail closed", () => {
   assert.equal(festivalSources.length, festivals.length);
   assert.equal(new Set(festivalSources.map(({ festivalSlug }) => festivalSlug)).size, festivals.length);
   assert.deepEqual(festivalSources.map(({ festivalSlug }) => festivalSlug).sort(), festivals.map(({ slug }) => slug).sort());
   for (const source of festivalSources) {
     assert.match(source.url, /^https:\/\//);
-    assert.equal(source.enabled, true);
     assert.ok(source.strategies.length > 0);
-    assert.ok(["daily", "every_3_days", "weekly"].includes(source.refreshPolicy));
+    if (source.enabled) assert.ok(["daily", "every_3_days", "weekly"].includes(source.refreshPolicy));
+    else {
+      assert.equal(source.refreshPolicy, "archived");
+      assert.deepEqual(source.strategies, ["manual_review"]);
+      assert.ok(source.manualReviewReason);
+    }
   }
 });
 

--- a/tests/ingestion-source-recovery.test.mjs
+++ b/tests/ingestion-source-recovery.test.mjs
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { festivals } from "../data/festivals.ts";
+import { getFestivalSource } from "../data/festival-sources.ts";
+import { extractFestivalCandidate } from "../lib/ingestion/extract.ts";
+import { isSourceDue } from "../lib/ingestion/schedule.ts";
+
+test("2000trees uses the active official domain and extracts its edition banner", () => {
+  const festival = festivals.find(({ slug }) => slug === "2000trees");
+  const source = getFestivalSource("2000trees");
+  assert.equal(festival?.officialUrl, "https://2000trees.co.uk/");
+  assert.equal(source?.url, festival?.officialUrl);
+  assert.deepEqual(source?.strategies, ["official_markup"]);
+  const candidate = extractFestivalCandidate('<p class="alt-subheading">7TH - 10TH JULY 2027</p>', source, "2026-09-01T00:00:00Z");
+  assert.equal(candidate.startDate, "2027-07-07");
+  assert.equal(candidate.endDate, "2027-07-10");
+  assert.deepEqual(candidate.observedEditionYears, [2027]);
+  assert.deepEqual(candidate.evidence.map(({ field }) => field), ["startDate", "endDate"]);
+});
+
+test("the defunct MetalDays source is retained as explicit disabled provenance", () => {
+  const source = getFestivalSource("metaldays");
+  assert.equal(source?.enabled, false);
+  assert.equal(source?.refreshPolicy, "archived");
+  assert.deepEqual(source?.strategies, ["manual_review"]);
+  assert.match(source?.manualReviewReason || "", /ended MetalDays in 2024/);
+  assert.equal(isSourceDue(source, new Date("2026-09-01T00:00:00Z")), false);
+});


### PR DESCRIPTION
Closes #22.

The persistent 403s had two different trust causes:
- 2000trees pointed at a stale/hijacked casino-content domain. The catalogue now uses the active official https://2000trees.co.uk/ source and a narrowly scoped official-markup adapter for its 2027 banner.
- MetalDays ended in 2024, so its former domain is not a valid 2027 source. It is retained as explicit disabled/archived provenance and excluded from due runs; public catalogue replacement/removal is tracked separately in #175.

Verification:
- data tests: 132 JS + 4 TS
- TypeScript typecheck
- Python tests: 60/60
- production build: 278 routes
- live official-source acceptance: HTTP 200, final URL 2000trees.co.uk, extracted 2027-07-07 through 2027-07-10, run COMPLETED with zero fetch errors
- extracted date changes remain review_required under publication policy