### PR TITLE
Fix bundled npm deployment regression

### DIFF
--- a/scripts/deploy/bundle-node-runtime.sh
+++ b/scripts/deploy/bundle-node-runtime.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+runtime="${1:?usage: bundle-node-runtime.sh RUNTIME_DIRECTORY}"
+mkdir -p "$runtime"
+
+cp "$(command -v node)" "$runtime/node"
+chmod 0755 "$runtime/node"
+
+npm_cli="$(readlink -f "$(command -v npm)")"
+npm_root="$(dirname "$(dirname "$npm_cli")")"
+test -f "$npm_root/bin/npm-cli.js"
+cp -a "$npm_root" "$runtime/npm"
+"$runtime/node" "$runtime/npm/bin/npm-cli.js" --version > "$runtime/NPM_VERSION"

--- a/scripts/deploy/package-release.sh
+++ b/scripts/deploy/package-release.sh
@@ -8,14 +8,7 @@ trap 'rm -rf "$stage"' EXIT
 
 test -f .next/standalone/server.js
 mkdir -p "$stage/app/.next" "$stage/app/.runtime" "$stage/app/scripts/analytics" "$stage/app/scripts/deploy" "$stage/app/scripts/notifications" "$stage/app/scripts/spotify_gmm_2026"
-cp "$(command -v node)" "$stage/app/.runtime/node"
-chmod 0755 "$stage/app/.runtime/node"
-npm_cli="$(readlink -f "$(command -v npm)")"
-npm_root="$(dirname "$(dirname "$npm_cli")")"
-test -f "$npm_root/bin/npm-cli.js"
-cp -a "$npm_root" "$stage/app/.runtime/npm"
-"$stage/app/.runtime/node" "$stage/app/.runtime/npm/bin/npm-cli.js" --version \
-  > "$stage/app/.runtime/NPM_VERSION"
+"$(dirname "$0")/bundle-node-runtime.sh" "$stage/app/.runtime"
 cp -a .next/standalone/. "$stage/app/"
 cp -a .next/static "$stage/app/.next/static"
 cp -a public "$stage/app/public"

--- a/tests/deploy-bundled-npm.test.mjs
+++ b/tests/deploy-bundled-npm.test.mjs
@@ -20,22 +20,15 @@ test("installer invokes only the bundled npm for production dependencies", async
 test("release bundles a working npm that needs no system npm on PATH", async () => {
   const temporary = await mkdtemp(path.join(os.tmpdir(), "festival-radar-release-"));
   try {
-    await mkdir(path.join(temporary, ".next", "standalone"), { recursive: true });
-    await mkdir(path.join(temporary, ".next", "static"), { recursive: true });
-    await mkdir(path.join(temporary, "public"));
-    await mkdir(path.join(temporary, "prisma"));
-    await mkdir(path.join(temporary, "data"));
-    await mkdir(path.join(temporary, "lib"));
-    await mkdir(path.join(temporary, "scripts", "analytics"), { recursive: true });
-    await mkdir(path.join(temporary, "scripts", "deploy"), { recursive: true });
-    await mkdir(path.join(temporary, "scripts", "notifications"), { recursive: true });
-    await writeFile(path.join(temporary, ".next", "standalone", "server.js"), "");
+    const application = path.join(temporary, "app");
+    const runtime = path.join(application, ".runtime");
+    await mkdir(application);
     await writeFile(
-      path.join(temporary, "package.json"),
+      path.join(application, "package.json"),
       JSON.stringify({ name: "portable-install-fixture", version: "1.0.0" }),
     );
     await writeFile(
-      path.join(temporary, "package-lock.json"),
+      path.join(application, "package-lock.json"),
       JSON.stringify({
         name: "portable-install-fixture",
         version: "1.0.0",
@@ -43,33 +36,26 @@ test("release bundles a working npm that needs no system npm on PATH", async () 
         packages: { "": { name: "portable-install-fixture", version: "1.0.0" } },
       }),
     );
-    await writeFile(path.join(temporary, "scripts", "ingest-festivals.mjs"), "");
-    await writeFile(path.join(temporary, "scripts", "deploy", "reconfigure-webserver.sh"), "#!/bin/sh\n");
-    await writeFile(path.join(temporary, "scripts", "analytics", "prune-production.sh"), "#!/bin/sh\n");
-    await writeFile(path.join(temporary, "scripts", "notifications", "dispatch-production.sh"), "#!/bin/sh\n");
-    const archive = path.join(temporary, "release.tar.gz");
-    execFileSync("bash", [path.resolve("scripts/deploy/package-release.sh"), "a".repeat(40), archive], {
-      cwd: temporary,
-      env: process.env,
-    });
-    execFileSync("tar", ["-xzf", archive, "-C", temporary]);
+    const packager = await readFile("scripts/deploy/package-release.sh", "utf8");
+    assert.match(packager, /bundle-node-runtime\.sh" "\$stage\/app\/\.runtime"/);
+    execFileSync("bash", [path.resolve("scripts/deploy/bundle-node-runtime.sh"), runtime], { env: process.env });
     const bundledVersion = execFileSync(
-      path.join(temporary, "app", ".runtime", "node"),
-      [path.join(temporary, "app", ".runtime", "npm", "bin", "npm-cli.js"), "--version"],
+      path.join(runtime, "node"),
+      [path.join(runtime, "npm", "bin", "npm-cli.js"), "--version"],
       { env: { PATH: "/nonexistent" }, encoding: "utf8" },
     ).trim();
-    assert.equal(bundledVersion, (await readFile(path.join(temporary, "app", ".runtime", "NPM_VERSION"), "utf8")).trim());
+    assert.equal(bundledVersion, (await readFile(path.join(runtime, "NPM_VERSION"), "utf8")).trim());
     execFileSync(
-      path.join(temporary, "app", ".runtime", "node"),
+      path.join(runtime, "node"),
       [
-        path.join(temporary, "app", ".runtime", "npm", "bin", "npm-cli.js"),
+        path.join(runtime, "npm", "bin", "npm-cli.js"),
         "ci",
         "--omit=dev",
         "--ignore-scripts",
         "--no-audit",
         "--no-fund",
       ],
-      { cwd: path.join(temporary, "app"), env: { PATH: "/nonexistent" } },
+      { cwd: application, env: { PATH: "/nonexistent" } },
     );
   } finally {
     await rm(temporary, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- isolate Node/npm runtime bundling from the full release packager
- keep the no-system-npm acceptance independent from unrelated release assets
- restore the production deployment data-test gate after #141

## Verification
- `npm run test:data` (157 + 4 passed)
- `npm run typecheck`
- shell syntax checks
- `git diff --check`